### PR TITLE
fix date property access in `Articles` component

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -33,16 +33,18 @@ function Articles() {
         }
         const data = await response.json();
 
-        const articlesData: Article[] = data.map((item: any) => ({
-          id: item.id,
-          title: item.title,
-          source: item.source,
-          createdAt: item.created_at,
-          updatedAt: item.updated_at,
-          summary: item.summary && item.summary.Valid ? item.summary.String : 'No summary available',
-          link: item.link,
-          isOnHomepage: item.is_on_homepage,
-        }));
+        const articlesData: Article[] = data.map((item: any) => {
+          return {
+            id: item.id,
+            title: item.title,
+            source: item.source,
+            createdAt: item.createdAt, 
+            updatedAt: item.updatedAt,
+            summary: item.summary && item.summary.Valid ? item.summary.String : 'No summary available',
+            link: item.link,
+            isOnHomepage: item.is_on_homepage,
+          };
+        });
         setArticles(articlesData);
       } catch (error) {
         console.error('Error fetching articles:', error);
@@ -53,7 +55,14 @@ function Articles() {
   }, []);
 
   const formatDate = (dateStr: string): string => {
+  // Handle null, undefined, or empty date strings
+    if (!dateStr) {
+      return 'Date not available'; 
+    }
     const date = new Date(dateStr);
+    if (isNaN(date.getTime())) {
+      return 'Invalid Date'; 
+    }
     return date.toLocaleDateString(undefined, {
       year: 'numeric', month: 'long', day: 'numeric'
     });


### PR DESCRIPTION
## Description

This PR fixes an issue where article dates were not displayed correctly on the frontend. The root cause was a property name mismatch: the frontend was incorrectly using snake_case (`created_at`) instead of camelCase (`createdAt`) which is how the dates are provided by the backend.

## Changes Made

- Adjusted the property names for `createdAt` and `updatedAt` in the `Articles` component to match the camelCase format provided by the backend.

## Testing

- Verified that the `formatDate` function correctly formats and displays these dates on the frontend.

## Checklist

- [x] My code follows the style guidelines and best practices of this project.
- [x] I have reviewed and tested the code changes thoroughly.
- [x] I have not added unit tests, as the change was in the data access logic and was visually confirmed.
- [x] All existing unit tests (if any) pass with the changes.
- [x] The changes do not introduce any known security vulnerabilities.
- [x] I have considered the impact of these changes on performance, scalability, and maintainability.
- [x] No documentation update is needed as this is a bug fix.
