### PR TITLE
clean up Cypress output in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run Cypress tests and capture output
         run: |
           cd frontend
-          npx cypress run | tee cypress-output.txt
+          npx cypress run | sed 's/\x1b\[[0-9;]*m//g' | tee cypress-output.txt
           if grep -q "All specs passed!" cypress-output.txt; then
             echo "Cypress tests passed"
           else


### PR DESCRIPTION
## Description

Improved log readability in GitHub Actions by removing ANSI color codes from Cypress output.

## Changes Made

- Added a `sed` command to strip ANSI color codes from Cypress test output.
- Routed cleaned output to `cypress-output.txt` for both review and archival.

## Testing

- Changes can be verified by observing the absence of color codes in the `cypress-output.txt` within GitHub Actions logs after execution.

## Checklist

- [x] Followed project style guidelines and best practices.
- [x] Thoroughly reviewed and tested code changes.
- [x] Confirmed no additional unit tests were required.
- [x] Verified that all existing tests are passing.
- [x] Ensured no introduction of security vulnerabilities.
- [x] Considered impacts on system performance, scalability, and maintainability.
