### PR TITLE
update `docker-compose` to use Docker Hub images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,7 @@
 version: '3.8'
 services:
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
-    image: nginx:latest
+    image: kjzehnder3/gophersignal:frontend-latest
     ports:
       - 80:80
       - 443:443
@@ -16,9 +13,7 @@ services:
       - app-network
 
   backend:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
+    image: kjzehnder3/gophersignal:backend-latest
     ports:
       - 8080:8080
     networks:


### PR DESCRIPTION
## Description

Updated the `docker-compose.yml` file to directly use the latest Docker images for the frontend and backend services from Docker Hub, instead of building them from local Dockerfiles.

## Changes

- Modified the `frontend` service in `docker-compose.yml` to use `kjzehnder3/gophersignal:frontend-latest`.
- Changed the `backend` service in `docker-compose.yml` to use `kjzehnder3/gophersignal:backend-latest`.
- Removed the `build` context from both `frontend` and `backend` services.

## Testing

- Pulled the latest Docker images from Docker Hub.
- Verified that the frontend and backend containers are running with the new images.

## Checklist

- [x] Changes align with project standards and best practices.
- [x] Docker Compose configuration updated and tested.
- [x] All services are running as expected with no new security vulnerabilities.
- [x] Documentation is updated to reflect changes in Docker deployment strategy.
