### PR TITLE
refactor Makefiles for frontend and backend builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@
 NEXT_PUBLIC_ENV=development
 
 # Backend
-MYSQL_DSN=user:password@tcp(localhost:3333)/gophersignal?parseTime=true
+MYSQL_DSN=user:password@tcp(localhost:3306)/gophersignal?parseTime=true
 SERVER_ADDRESS=0.0.0.0:8080

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,17 @@ BACKEND_TAG = $(DOCKERHUB_REPO):backend-$(VERSION)
 DOCKER_COMPOSE = docker-compose
 DOCKERHUB_REPO = kjzehnder3/gophersignal
 
+export FRONTEND_TAG BACKEND_TAG DOCKERHUB_REPO
+
 .PHONY: all build-frontend build-backend run stop down test docker_push_frontend docker_push_backend all-push
 
 all: build-frontend build-backend run
 
 build-frontend:
-	cd frontend && docker build -t $(FRONTEND_TAG) .
+	cd frontend && make build
 
 build-backend:
-	cd backend && docker build -t $(BACKEND_TAG) .
+	cd backend && make build
 
 run:
 	$(DOCKER_COMPOSE) up -d
@@ -24,7 +26,6 @@ down:
 	$(DOCKER_COMPOSE) down
 
 test:
-	# Backend tests
 	cd backend && go test -v -cover ./...
 
 docker_push_frontend:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,7 +1,7 @@
-.PHONY: build-backend run-backend
+.PHONY: build run
 
-build-backend:
-	docker build -t my-backend-image .
+build:
+	docker build -t $(BACKEND_TAG) .
 
-run-backend:
+run:
 	docker-compose up -d backend

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build run
 
 build:
-	docker build -t my-frontend-image .
+	docker build -t $(FRONTEND_TAG) .
 
 run:
 	docker-compose up -d frontend


### PR DESCRIPTION
## Description

This pull request revises the `Makefile` for the frontend and backend components. The update simplifies the build process by introducing specific variables and segregating commands for each component. These changes enhance the ease of use and pave the way for future enhancements in our build system.

## Changes Made

- Exported `FRONTEND_TAG`, `BACKEND_TAG`, and `DOCKERHUB_REPO` in the main Makefile for uniform usage.
- Updated Makefiles in both frontend and backend to utilize these Docker tags, clarifying the build process for each component.
- Altered `build-frontend` and `build-backend` in the main Makefile to call build commands directly in respective directories.

## Testing

- Verified correct tagging of Docker images with `FRONTEND_TAG` and `BACKEND_TAG`.
- Conducted tests with Docker Compose to confirm smooth startup of both frontend and backend services.

## Checklist

- [x] Followed project's coding guidelines.
- [x] Conducted comprehensive testing of changes.
- [x] Updated or added unit tests as needed.
- [x] Confirmed passing of all existing tests.
- [x] Evaluated for security vulnerabilities.
- [x] Assessed impact on performance, scalability, and maintainability.
- [x] Updated relevant documentation.
