### PR TITLE
change gh action workflow target to `make all_push`

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,7 +24,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build, test, and push images
-        run: make all
+        run: make all_push
 
       - name: Upload Go coverage report
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description

This pull request updates the main target in the `GitHub Action` workflow to `make all_push` from `make all`. This change ensures that built and tested images are pushed to `DockerHub`, making them available for deployment.

## Changes Made

- Updated the build process to use the `make all_push` target instead of `make all`.

## Testing

The changes have undergone testing in a local development environment, including unit tests.

## Checklist

- [x] Code adheres to project style guidelines and best practices.
- [x] Code changes have been thoroughly reviewed and tested.
- [x] Unit tests have been added or updated to ensure code correctness.
- [x] All existing unit tests pass with the changes.
- [x] The changes do not introduce any known security vulnerabilities.
- [x] Consideration has been given to the impact of these changes on performance, scalability, and maintainability.
- [x] Documentation has been updated to reflect the introduced changes (if applicable).