### PR TITLE
fix: Correct CMD instruction in Dockerfile

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -17,4 +17,4 @@ COPY . .
 EXPOSE 3000
 
 # Define the command to run your app using CMD which defines your runtime
-CMD ["next", "dev"]
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
### Pull Request Template

#### Description
This PR fixes a typo in the frontend `Dockerfile.dev` where the `CMD` instruction was set to `"next dev"` instead of `"npm run dev"`.

#### Changes
- Corrected the `CMD` instruction in the Dockerfile to use `"npm run dev"`.

#### Testing
- Tested the Docker container to ensure that the corrected command runs the application as expected.

#### Checklist
- [x] The code follows project standards.
- [x] The changes have been thoroughly tested.
- [x] No new security vulnerabilities are introduced with the correction.
- [x] Documentation has been updated as necessary.
