### PR TITLE
set `Swagger` host to gophersignal.com

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -24,7 +24,7 @@ func Init() string {
 	if env == "dev" {
 		docs.SwaggerInfo.Host = "localhost:8080"
 	} else {
-		docs.SwaggerInfo.Host = "0.0.0.0:8080"
+		docs.SwaggerInfo.Host = "gophersignal.com"
 	}
 
 	return dsn


### PR DESCRIPTION
## Description

This pull request updates the Swagger host configuration in our backend service. The Swagger host, previously set to `0.0.0.0:8080`, has now been changed to `gophersignal.com` for environments other than development. This change ensures accurate API documentation hosting, aligning it with our production domain.

## Changes Made

- **Configuration Update**: Modified the Swagger host setting in the backend configuration. In development (`GO_ENV` set to `dev`), it remains `localhost:8080`. For other environments, it's now set to `gophersignal.com`.

## Testing

- Verified that Swagger documentation is correctly hosted at `localhost:8080` in the development environment.
- Confirmed that the Swagger host points to `gophersignal.com` in non-development environments.
- Conducted general functionality tests to ensure no disruptions from this configuration change.

## Checklist

- [x] Adhered to code guidelines.
- [x] Completed testing of the changes.
- [x] Checked for any impact on performance.
- [x] Ensured no security vulnerabilities are introduced.
- [x] Updated documentation as necessary.