### PR TITLE
Optimize article TTL to 600s, Hugging Face API stable

### DIFF
--- a/backend/internal/api/routeHandlers/routeHandlers.go
+++ b/backend/internal/api/routeHandlers/routeHandlers.go
@@ -55,8 +55,8 @@ func (h *ArticlesHandler) GetArticles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set cache headers for the response for 900 seconds (i.e., 15 minutes).
-	h.setCacheHeaders(w, 900)
+	// Set cache headers for the response for 600 seconds (i.e., 10 minutes).
+	h.setCacheHeaders(w, 600)
 
 	// Send a JSON response with the retrieved articles and HTTP status OK (200).
 	h.jsonResponse(w, articles, http.StatusOK)


### PR DESCRIPTION
## Description

This PR adjusts the articles cache `TTL` from 900 to 600 seconds. The initial increase was in response to the `Hugging Face` API downtime, which required reliance on a slower, locally-run `BERT` model for data scraping and summarization. This increase was essential to prevent database inconsistencies due to the longer processing times of partially processed articles. Now that the `Hugging Face` API is stable and efficient, the `TTL` is being changed back to 600 seconds to enhance content freshness and maintain data integrity across database operations.

## Changes Made

- Updated cache control headers from 900 seconds back to 600 seconds.

## Testing

- Verified the new TTL settings in test environments, acknowledging limitations in fully simulating production conditions.

## Checklist

- [x] Followed project's style guidelines and best practices.
- [x] Conducted thorough testing of changes.
- [x] Updated relevant documentation to reflect the new cache settings.
- [x] Assessed changes for potential impacts on system performance and scalability.
- [x] Ensured that no new security vulnerabilities are introduced.