### PR TITLE
fix: Rename API controllers to handlers to align with Go practices

### DIFF
--- a/backend/internal/api/handlers/articles.go
+++ b/backend/internal/api/handlers/articles.go
@@ -1,5 +1,5 @@
-// Package controllers handles HTTP requests for the GopherSignal application.
-package controllers
+// Package handlers handles HTTP requests for the GopherSignal application.
+package handlers
 
 import (
 	"encoding/json"
@@ -10,24 +10,24 @@ import (
 	"github.com/k-zehnder/gophersignal/backend/internal/store"
 )
 
-// Controller defines the interface for controllers that handle HTTP requests.
+// Handler defines the interface for handlers that manage HTTP requests.
 // It extends the http.Handler interface by expecting implementation of ServeHTTP.
-type Controller interface {
+type Handler interface {
 	http.Handler
 }
 
-// ArticlesController manages article-related HTTP requests.
-type ArticlesController struct {
+// ArticlesHandler manages article-related HTTP requests.
+type ArticlesHandler struct {
 	Store store.Store // Store provides access to the data layer.
 }
 
-// NewArticlesController creates a new ArticlesController with the provided store.
-func NewArticlesController(store store.Store) *ArticlesController {
-	return &ArticlesController{Store: store}
+// NewArticlesHandler creates a new ArticlesHandler with the provided store.
+func NewArticlesHandler(store store.Store) *ArticlesHandler {
+	return &ArticlesHandler{Store: store}
 }
 
-// ServeHTTP routes HTTP requests to the appropriate controller methods.
-func (h *ArticlesController) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+// ServeHTTP routes HTTP requests to the appropriate handler methods.
+func (h *ArticlesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "GET" {
 		h.GetArticles(w, r)
 	} else {
@@ -45,7 +45,7 @@ func (h *ArticlesController) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // @Failure 400 {object} models.ErrorResponse "Bad Request"
 // @Failure 500 {object} models.ErrorResponse "Internal Server Error"
 // @Router /articles [get]
-func (h *ArticlesController) GetArticles(w http.ResponseWriter, r *http.Request) {
+func (h *ArticlesHandler) GetArticles(w http.ResponseWriter, r *http.Request) {
 	articles, err := h.Store.GetArticles()
 	if err != nil {
 		h.jsonErrorResponse(w, models.ErrorResponse{
@@ -66,20 +66,20 @@ func (h *ArticlesController) GetArticles(w http.ResponseWriter, r *http.Request)
 }
 
 // setCacheHeaders adds caching headers to the HTTP response.
-func (h *ArticlesController) setCacheHeaders(w http.ResponseWriter, maxAgeSeconds int) {
+func (h *ArticlesHandler) setCacheHeaders(w http.ResponseWriter, maxAgeSeconds int) {
 	cacheControl := fmt.Sprintf("public, max-age=%d", maxAgeSeconds)
 	w.Header().Set("Cache-Control", cacheControl)
 }
 
 // jsonResponse sends a JSON response with the specified data and status code.
-func (h *ArticlesController) jsonResponse(w http.ResponseWriter, response interface{}, statusCode int) {
+func (h *ArticlesHandler) jsonResponse(w http.ResponseWriter, response interface{}, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	json.NewEncoder(w).Encode(response)
 }
 
 // jsonErrorResponse sends a JSON error response with the specified data and status code.
-func (h *ArticlesController) jsonErrorResponse(w http.ResponseWriter, response models.ErrorResponse, statusCode int) {
+func (h *ArticlesHandler) jsonErrorResponse(w http.ResponseWriter, response models.ErrorResponse, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	json.NewEncoder(w).Encode(response)

--- a/backend/internal/api/handlers/articles_test.go
+++ b/backend/internal/api/handlers/articles_test.go
@@ -1,5 +1,5 @@
-// Package controllers contains unit tests for HTTP controller functions.
-package controllers
+// Package handlers contains unit tests for HTTP handler functions.
+package handlers
 
 import (
 	"errors"
@@ -11,62 +11,62 @@ import (
 	"github.com/k-zehnder/gophersignal/backend/internal/store"
 )
 
-// TestGetArticles_Success tests the GetArticles controller for a successful response.
+// TestGetArticles_Success tests the GetArticles handler for a successful response.
 func TestGetArticles_Success(t *testing.T) {
 	// Set up a mock store with predefined data to simulate database interactions.
 	mockStore := store.NewMockStore([]*models.Article{{Title: "Test Article 1"}}, nil, nil)
 
-	// Initialize the controller with the mock store.
-	controller := NewArticlesController(mockStore)
+	// Initialize the handler with the mock store.
+	handler := NewArticlesHandler(mockStore)
 
 	// Create a new HTTP GET request for the articles endpoint.
 	req := httptest.NewRequest("GET", "/dummy-url", nil)
 	rr := httptest.NewRecorder()
 
 	// Serve the HTTP request and record the response.
-	controller.ServeHTTP(rr, req)
+	handler.ServeHTTP(rr, req)
 
 	// Check if the response status code is as expected (200 OK).
 	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("controller returned wrong status code: got %v want %v", status, http.StatusOK)
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 }
 
-// TestGetArticles_Error tests the GetArticles controller for an error scenario.
+// TestGetArticles_Error tests the GetArticles handler for an error scenario.
 func TestGetArticles_Error(t *testing.T) {
 	// Set up a mock store to simulate an error scenario.
 	mockStore := store.NewMockStore(nil, nil, errors.New("database error"))
 
-	// Initialize the controller with the mock store.
-	controller := NewArticlesController(mockStore)
+	// Initialize the handler with the mock store.
+	handler := NewArticlesHandler(mockStore)
 
 	// Create a new HTTP GET request for the articles endpoint.
 	req := httptest.NewRequest("GET", "/dummy-url", nil)
 	rr := httptest.NewRecorder()
 
 	// Serve the HTTP request and record the response.
-	controller.ServeHTTP(rr, req)
+	handler.ServeHTTP(rr, req)
 
 	// Check if the response status code is as expected (500 Internal Server Error).
 	if status := rr.Code; status != http.StatusInternalServerError {
-		t.Errorf("controller returned wrong status code: got %v want %v", status, http.StatusInternalServerError)
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusInternalServerError)
 	}
 }
 
 // TestServeHTTP_MethodNotAllowed tests the ServeHTTP method for non-GET requests.
 func TestServeHTTP_MethodNotAllowed(t *testing.T) {
-	// Initialize the controller with a mock store (can be nil as it's not used in this test).
-	controller := NewArticlesController(nil)
+	// Initialize the handler with a mock store (can be nil as it's not used in this test).
+	handler := NewArticlesHandler(nil)
 
 	// Create a new HTTP POST request (or any non-GET request).
 	req := httptest.NewRequest("POST", "/dummy-url", nil)
 	rr := httptest.NewRecorder()
 
 	// Serve the HTTP request and record the response.
-	controller.ServeHTTP(rr, req)
+	handler.ServeHTTP(rr, req)
 
 	// Check if the response status code is as expected (405 Method Not Allowed).
 	if status := rr.Code; status != http.StatusMethodNotAllowed {
-		t.Errorf("controller returned wrong status code: got %v want %v", status, http.StatusMethodNotAllowed)
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusMethodNotAllowed)
 	}
 }

--- a/backend/internal/api/router/router.go
+++ b/backend/internal/api/router/router.go
@@ -5,39 +5,39 @@ package router
 import (
 	"net/http"
 
-	"github.com/gorilla/handlers"
+	gorillaHandlers "github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	"github.com/k-zehnder/gophersignal/backend/internal/api/controllers"
+	"github.com/k-zehnder/gophersignal/backend/internal/api/handlers"
 	"github.com/k-zehnder/gophersignal/backend/internal/store"
 	httpSwagger "github.com/swaggo/http-swagger"
 )
 
-// NewRouter creates an http.Handler with configured routes and controllers.
+// NewRouter creates an http.Handler with configured routes and handlers.
 func NewRouter(store store.Store) http.Handler {
-	articlesController := controllers.NewArticlesController(store)
-	return SetupRouter(articlesController)
+	articlesHandler := handlers.NewArticlesHandler(store)
+	return SetupRouter(articlesHandler)
 }
 
 // SetupRouter initializes and returns a configured mux.Router.
-func SetupRouter(articlesController *controllers.ArticlesController) *mux.Router {
+func SetupRouter(articlesHandler *handlers.ArticlesHandler) *mux.Router {
 	r := mux.NewRouter()
 
 	// Setup CORS for various development and production environments
-	cors := handlers.CORS(
-		handlers.AllowedOrigins([]string{
+	cors := gorillaHandlers.CORS(
+		gorillaHandlers.AllowedOrigins([]string{
 			"http://localhost:3000",        // Local frontend dev server
 			"http://localhost:8080",        // Local dev server
 			"https://gophersignal.com",     // Production frontend
 			"https://www.gophersignal.com", // Production frontend with www
 		}),
-		handlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS"}),
-		handlers.AllowedHeaders([]string{"Content-Type", "Authorization"}),
+		gorillaHandlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS"}),
+		gorillaHandlers.AllowedHeaders([]string{"Content-Type", "Authorization"}),
 	)
 	r.Use(cors)
 
 	// Setup API v1 routes, including the GET endpoint for articles
 	apiRouter := r.PathPrefix("/api/v1").Subrouter()
-	apiRouter.Handle("/articles", articlesController)
+	apiRouter.Handle("/articles", articlesHandler)
 
 	// Enable Swagger documentation at '/swagger'
 	r.PathPrefix("/swagger").Handler(httpSwagger.WrapHandler)

--- a/backend/internal/api/router/router_test.go
+++ b/backend/internal/api/router/router_test.go
@@ -1,5 +1,4 @@
 // Package router contains the unit tests for verifying the router configuration and route handling in the GopherSignal application.
-
 package router
 
 import (
@@ -7,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/k-zehnder/gophersignal/backend/internal/api/controllers"
+	"github.com/k-zehnder/gophersignal/backend/internal/api/handlers"
 	"github.com/k-zehnder/gophersignal/backend/internal/models"
 	"github.com/k-zehnder/gophersignal/backend/internal/store"
 )
@@ -18,7 +17,7 @@ func TestRouter_ArticlesRoute(t *testing.T) {
 	mockStore := store.NewMockStore([]*models.Article{}, nil, nil)
 
 	// Initialize the ArticlesHandler with the mock store.
-	articlesHandler := controllers.NewArticlesController(mockStore)
+	articlesHandler := handlers.NewArticlesHandler(mockStore)
 
 	// Set up the router.
 	router := SetupRouter(articlesHandler)

--- a/backend/internal/api/server/server.go
+++ b/backend/internal/api/server/server.go
@@ -9,17 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
-
-	"github.com/k-zehnder/gophersignal/backend/internal/api/controllers"
-	"github.com/k-zehnder/gophersignal/backend/internal/api/router"
-	"github.com/k-zehnder/gophersignal/backend/internal/store"
 )
-
-// NewRouter creates an http.Handler with configured routes and controllers.
-func NewRouter(store store.Store) http.Handler {
-	articlesController := controllers.NewArticlesController(store)
-	return router.SetupRouter(articlesController)
-}
 
 // StartServer launches an HTTP server on the specified address.
 func StartServer(addr string, handler http.Handler) *http.Server {


### PR DESCRIPTION
## Description

This pull request refactors the codebase by renaming `Controller` to `Handler` across various files to make the code more idiomatic and readable in Go. The changes ensure consistency, improve clarity, and align with Go conventions.

## Changes Made

- Replaced all instances of `Controller` with `Handler`, including functions, variables, and comments.
- Updated router configuration, Swagger documentation references, and unit tests to reflect the renaming.
- Resolved name collisions by aliasing imports where necessary.

## Testing

- Ran all existing unit tests and confirmed that all tests pass after the refactor.
- Manually tested the application to ensure no issues were introduced.
- Verified that all routes function correctly with the new handler structure.

## Checklist

- [x] Code adheres to project style guidelines and best practices.
- [x] Code changes have been thoroughly reviewed and tested.
- [x] Unit tests have been updated, and all tests pass.
- [x] Documentation has been updated to reflect the changes (if applicable).
