### PR TITLE
fix: Ensure users cannot click dead link for 0 comments in RSS feed

### DIFF
--- a/rss/src/routes/rss.rs
+++ b/rss/src/routes/rss.rs
@@ -1,4 +1,4 @@
-//! RSS feed generator for GopherSignal using in-memory deduplication
+//! RSS feed generator for GopherSignal using in-memory deduplication.
 
 use crate::{
     config::config::AppConfig, errors::errors::AppError, models::article::Article,

--- a/rss/src/routes/rss.rs
+++ b/rss/src/routes/rss.rs
@@ -23,7 +23,7 @@ pub struct RssQuery {
     pub dupe: Option<bool>,
 }
 
-/// Generate the RSS feed
+/// Generate the RSS feed.
 pub async fn generate_rss_feed<T: ArticlesClient + Clone>(
     Query(query): Query<RssQuery>,
     Extension(config): Extension<AppConfig>,

--- a/rss/src/routes/rss.rs
+++ b/rss/src/routes/rss.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use htmlescape::encode_minimal;
-use rss::{ChannelBuilder, ItemBuilder};
+use rss::{ChannelBuilder, Guid, ItemBuilder};
 use serde::Deserialize;
 use std::collections::HashSet;
 use url::Url;
@@ -104,7 +104,7 @@ fn build_item(article: &Article) -> rss::Item {
         .link(Some(article.link.clone()))
         .description(Some(description))
         .pub_date(Some(pub_date))
-        .guid(Some(rss::Guid {
+        .guid(Some(Guid {
             value: article.link.clone(),
             permalink: true,
         }))


### PR DESCRIPTION
## PR Description

Addresses [#361](https://github.com/k-zehnder/gophersignal/issues/361)

This pull request improves the comment rendering in our RSS feed. Previously, every article showed a clickable comment link regardless of the count. Now, if an article has zero comments, "💬 0 comments" is rendered as plain text so that there is no dead link.

### Changes Made

- Render comment output as plain text when comment count is zero so users cannot click a non-existent URL

### Testing

- Verified that articles with non-zero comment counts still display a clickable link with the count.
- Confirmed that articles with zero comments now display "💬 0 comments" as plain text.

### Checklist

- [x] Code adheres to the project’s style guidelines and best practices.
- [x] Changes have been thoroughly reviewed and tested.
- [x] Unit tests have been updated to cover these modifications.
- [x] All existing tests pass.
- [x] No known security vulnerabilities are introduced.
- [x] Impact on performance, scalability, and maintainability has been considered.
- [x] Documentation has been updated as necessary.
