### PR TITLE
feat: Enable user-tailored RSS filtering by votes and comments

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -17,7 +17,7 @@ const docTemplate = `{
     "paths": {
         "/articles": {
             "get": {
-                "description": "Retrieve a list of articles from the database. Optional query parameters",
+                "description": "Retrieve paginated articles with optional filters and thresholds",
                 "consumes": [
                     "application/json"
                 ],
@@ -27,7 +27,7 @@ const docTemplate = `{
                 "tags": [
                     "Articles"
                 ],
-                "summary": "Get articles",
+                "summary": "Get filtered articles",
                 "parameters": [
                     {
                         "type": "boolean",
@@ -48,23 +48,44 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "maximum": 100,
+                        "minimum": 1,
                         "type": "integer",
                         "default": 30,
-                        "description": "Limit the number of articles returned (default is 30)",
+                        "description": "Results per page (max 100)",
                         "name": "limit",
                         "in": "query"
                     },
                     {
+                        "minimum": 0,
                         "type": "integer",
                         "default": 0,
-                        "description": "Offset for pagination (default is 0)",
+                        "description": "Pagination offset",
                         "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "format": "int64",
+                        "default": 0,
+                        "description": "Minimum upvotes threshold",
+                        "name": "min_upvotes",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "format": "int64",
+                        "default": 0,
+                        "description": "Minimum comments threshold",
+                        "name": "min_comments",
                         "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Articles data",
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/models.ArticlesResponse"
                         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -10,7 +10,7 @@
     "paths": {
         "/articles": {
             "get": {
-                "description": "Retrieve a list of articles from the database. Optional query parameters",
+                "description": "Retrieve paginated articles with optional filters and thresholds",
                 "consumes": [
                     "application/json"
                 ],
@@ -20,7 +20,7 @@
                 "tags": [
                     "Articles"
                 ],
-                "summary": "Get articles",
+                "summary": "Get filtered articles",
                 "parameters": [
                     {
                         "type": "boolean",
@@ -41,23 +41,44 @@
                         "in": "query"
                     },
                     {
+                        "maximum": 100,
+                        "minimum": 1,
                         "type": "integer",
                         "default": 30,
-                        "description": "Limit the number of articles returned (default is 30)",
+                        "description": "Results per page (max 100)",
                         "name": "limit",
                         "in": "query"
                     },
                     {
+                        "minimum": 0,
                         "type": "integer",
                         "default": 0,
-                        "description": "Offset for pagination (default is 0)",
+                        "description": "Pagination offset",
                         "name": "offset",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "format": "int64",
+                        "default": 0,
+                        "description": "Minimum upvotes threshold",
+                        "name": "min_upvotes",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "format": "int64",
+                        "default": 0,
+                        "description": "Minimum comments threshold",
+                        "name": "min_comments",
                         "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Articles data",
+                        "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/models.ArticlesResponse"
                         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -87,7 +87,7 @@ paths:
     get:
       consumes:
       - application/json
-      description: Retrieve a list of articles from the database. Optional query parameters
+      description: Retrieve paginated articles with optional filters and thresholds
       parameters:
       - description: Filter by flagged status
         in: query
@@ -102,20 +102,37 @@ paths:
         name: dupe
         type: boolean
       - default: 30
-        description: Limit the number of articles returned (default is 30)
+        description: Results per page (max 100)
         in: query
+        maximum: 100
+        minimum: 1
         name: limit
         type: integer
       - default: 0
-        description: Offset for pagination (default is 0)
+        description: Pagination offset
         in: query
+        minimum: 0
         name: offset
+        type: integer
+      - default: 0
+        description: Minimum upvotes threshold
+        format: int64
+        in: query
+        minimum: 0
+        name: min_upvotes
+        type: integer
+      - default: 0
+        description: Minimum comments threshold
+        format: int64
+        in: query
+        minimum: 0
+        name: min_comments
         type: integer
       produces:
       - application/json
       responses:
         "200":
-          description: Articles data
+          description: OK
           schema:
             $ref: '#/definitions/models.ArticlesResponse'
         "400":
@@ -126,7 +143,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/models.ErrorResponse'
-      summary: Get articles
+      summary: Get filtered articles
       tags:
       - Articles
 swagger: "2.0"

--- a/backend/internal/api/handlers/articles.go
+++ b/backend/internal/api/handlers/articles.go
@@ -1,4 +1,3 @@
-// Package handlers handles HTTP requests for the GopherSignal application.
 package handlers
 
 import (
@@ -37,25 +36,26 @@ func (h *ArticlesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // GetArticles handles the HTTP request to retrieve articles.
 //
-// @Summary Get articles
-// @Description Retrieve a list of articles from the database. Optional query parameters
-// can be provided to filter results by flagged, dead, and dupe statuses. Additionally,
-// pagination parameters `limit` and `offset` are supported.
+// @Summary Get filtered articles
+// @Description Retrieve paginated articles with optional filters and thresholds
 // @Tags Articles
-// @Accept json
-// @Produce json
-// @Param flagged query bool false "Filter by flagged status"
-// @Param dead query bool false "Filter by dead status"
-// @Param dupe query bool false "Filter by duplicate status"
-// @Param limit query int false "Limit the number of articles returned (default is 30)" default(30)
-// @Param offset query int false "Offset for pagination (default is 0)" default(0)
-// @Success 200 {object} models.ArticlesResponse "Articles data"
-// @Failure 400 {object} models.ErrorResponse "Bad Request"
-// @Failure 500 {object} models.ErrorResponse "Internal Server Error"
+// @Accept  json
+// @Produce  json
+// @Param   flagged       query   boolean  false  "Filter by flagged status"
+// @Param   dead          query   boolean  false  "Filter by dead status"
+// @Param   dupe          query   boolean  false  "Filter by duplicate status"
+// @Param   limit         query   integer  false  "Results per page (max 100)"  default(30) minimum(1) maximum(100)
+// @Param   offset        query   integer  false  "Pagination offset"            default(0) minimum(0)
+// @Param   min_upvotes   query   integer  false  "Minimum upvotes threshold"    default(0) minimum(0) format(int64)
+// @Param   min_comments  query   integer  false  "Minimum comments threshold"   default(0) minimum(0) format(int64)
+// @Success 200 {object} models.ArticlesResponse
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
 // @Router /articles [get]
 func (h *ArticlesHandler) GetArticles(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
+	// Parse optional boolean filters.
 	var flagged *bool
 	if flaggedStr := q.Get("flagged"); flaggedStr != "" {
 		f, err := strconv.ParseBool(flaggedStr)
@@ -69,7 +69,6 @@ func (h *ArticlesHandler) GetArticles(w http.ResponseWriter, r *http.Request) {
 		}
 		flagged = &f
 	}
-
 	var dead *bool
 	if deadStr := q.Get("dead"); deadStr != "" {
 		d, err := strconv.ParseBool(deadStr)
@@ -83,7 +82,6 @@ func (h *ArticlesHandler) GetArticles(w http.ResponseWriter, r *http.Request) {
 		}
 		dead = &d
 	}
-
 	var dupe *bool
 	if dupeStr := q.Get("dupe"); dupeStr != "" {
 		d, err := strconv.ParseBool(dupeStr)
@@ -112,13 +110,32 @@ func (h *ArticlesHandler) GetArticles(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Extract optional threshold parameters.
+	// A value of 0 means no threshold filtering.
+	minUpvotes := 0
+	minComments := 0
+	if upStr := q.Get("min_upvotes"); upStr != "" {
+		if up, err := strconv.Atoi(upStr); err == nil {
+			minUpvotes = up
+		}
+	}
+	if commStr := q.Get("min_comments"); commStr != "" {
+		if comm, err := strconv.Atoi(commStr); err == nil {
+			minComments = comm
+		}
+	}
+
 	var (
 		articles []*models.Article
 		err      error
 	)
-	// If any filtering query parameter is provided, use the filtered query.
-	// Otherwise, use the default query.
-	if flagged != nil || dead != nil || dupe != nil {
+
+	// Determine which store method to call based on provided filters.
+	if (minUpvotes > 0 || minComments > 0) && (flagged != nil || dead != nil || dupe != nil) {
+		articles, err = h.Store.GetArticlesWithThresholdsAndFilters(limit, offset, minUpvotes, minComments, flagged, dead, dupe)
+	} else if minUpvotes > 0 || minComments > 0 {
+		articles, err = h.Store.GetArticlesWithThresholds(limit, offset, minUpvotes, minComments)
+	} else if flagged != nil || dead != nil || dupe != nil {
 		articles, err = h.Store.GetFilteredArticles(flagged, dead, dupe, limit, offset)
 	} else {
 		articles, err = h.Store.GetArticles(limit, offset)
@@ -133,7 +150,7 @@ func (h *ArticlesHandler) GetArticles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.setCacheHeaders(w, h.Config.CacheMaxAge) 
+	h.setCacheHeaders(w, h.Config.CacheMaxAge)
 	h.jsonResponse(w, models.ArticlesResponse{
 		Code:       http.StatusOK,
 		Status:     "success",

--- a/backend/internal/api/router/router.go
+++ b/backend/internal/api/router/router.go
@@ -39,8 +39,6 @@ func SetupRouter(articlesHandler *handlers.ArticlesHandler) *mux.Router {
 
 	// Setup API v1 routes.
 	apiRouter := r.PathPrefix("/api/v1").Subrouter()
-
-	// Endpoint for retrieving articles.
 	apiRouter.Handle("/articles", articlesHandler).Methods("GET")
 
 	// Endpoint for Swagger documentation at '/swagger'.

--- a/backend/internal/models/article.go
+++ b/backend/internal/models/article.go
@@ -12,6 +12,11 @@ type NullableInt struct {
 	sql.NullInt64
 }
 
+// NewNullableInt returns a new NullableInt with the given value marked as valid.
+func NewNullableInt(value int64) NullableInt {
+	return NullableInt{sql.NullInt64{Int64: value, Valid: true}}
+}
+
 // MarshalJSON customizes JSON output for NullableInt.
 func (n NullableInt) MarshalJSON() ([]byte, error) {
 	if n.Valid {

--- a/backend/internal/store/mockstore.go
+++ b/backend/internal/store/mockstore.go
@@ -2,7 +2,9 @@
 // It includes a MockStore type, which serves as a testing double for the Store interface.
 package store
 
-import "github.com/k-zehnder/gophersignal/backend/internal/models"
+import (
+	"github.com/k-zehnder/gophersignal/backend/internal/models"
+)
 
 // MockStore serves as a testing double for the Store interface.
 type MockStore struct {
@@ -30,12 +32,10 @@ func (ms *MockStore) SaveArticles(articles []*models.Article) error {
 }
 
 // GetArticles simulates fetching articles, returning a predefined error if set.
-// It applies pagination (limit, offset) to the stored articles.
 func (ms *MockStore) GetArticles(limit, offset int) ([]*models.Article, error) {
 	if ms.GetAllError != nil {
 		return nil, ms.GetAllError
 	}
-	// Simple pagination: slice the Articles slice.
 	if offset >= len(ms.Articles) {
 		return []*models.Article{}, nil
 	}
@@ -47,8 +47,6 @@ func (ms *MockStore) GetArticles(limit, offset int) ([]*models.Article, error) {
 }
 
 // GetFilteredArticles simulates fetching articles based on optional filter criteria.
-// Each filter is provided as a pointer to a bool. If a filter is nil, that field is not filtered.
-// It applies pagination (limit, offset) and returns at most 'limit' articles starting at 'offset'.
 func (ms *MockStore) GetFilteredArticles(flagged, dead, dupe *bool, limit, offset int) ([]*models.Article, error) {
 	if ms.GetAllError != nil {
 		return nil, ms.GetAllError
@@ -56,21 +54,97 @@ func (ms *MockStore) GetFilteredArticles(flagged, dead, dupe *bool, limit, offse
 
 	var filtered []*models.Article
 	for _, article := range ms.Articles {
-		// Apply the flagged filter if provided.
 		if flagged != nil && article.Flagged != *flagged {
 			continue
 		}
-		// Apply the dead filter if provided.
 		if dead != nil && article.Dead != *dead {
 			continue
 		}
-		// Apply the dupe filter if provided.
 		if dupe != nil && article.Dupe != *dupe {
 			continue
 		}
 		filtered = append(filtered, article)
 	}
-	// Apply pagination to the filtered results.
+	if offset >= len(filtered) {
+		return []*models.Article{}, nil
+	}
+	end := offset + limit
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	return filtered[offset:end], nil
+}
+
+// GetArticlesWithThresholds implements threshold-based filtering.
+// It converts models.NullableInt values to int64 for comparison.
+// If minUpvotes or minComments is 0, that metric is not filtered.
+func (ms *MockStore) GetArticlesWithThresholds(limit, offset, minUpvotes, minComments int) ([]*models.Article, error) {
+	if ms.GetAllError != nil {
+		return nil, ms.GetAllError
+	}
+
+	var filtered []*models.Article
+	for _, article := range ms.Articles {
+		// Convert Upvotes and CommentCount from NullableInt to int64.
+		upvotes := int64(0)
+		if article.Upvotes.Valid {
+			upvotes = article.Upvotes.Int64
+		}
+		comments := int64(0)
+		if article.CommentCount.Valid {
+			comments = article.CommentCount.Int64
+		}
+
+		if upvotes >= int64(minUpvotes) && comments >= int64(minComments) {
+			filtered = append(filtered, article)
+		}
+	}
+
+	if offset >= len(filtered) {
+		return []*models.Article{}, nil
+	}
+	end := offset + limit
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	return filtered[offset:end], nil
+}
+
+// GetArticlesWithThresholdsAndFilters implements combined filtering:
+// both threshold conditions (minUpvotes and minComments) and additional boolean filters.
+func (ms *MockStore) GetArticlesWithThresholdsAndFilters(limit, offset, minUpvotes, minComments int, flagged, dead, dupe *bool) ([]*models.Article, error) {
+	if ms.GetAllError != nil {
+		return nil, ms.GetAllError
+	}
+
+	var filtered []*models.Article
+	for _, article := range ms.Articles {
+		// Apply boolean filters.
+		if flagged != nil && article.Flagged != *flagged {
+			continue
+		}
+		if dead != nil && article.Dead != *dead {
+			continue
+		}
+		if dupe != nil && article.Dupe != *dupe {
+			continue
+		}
+
+		// Convert Upvotes and CommentCount from NullableInt to int64.
+		upvotes := int64(0)
+		if article.Upvotes.Valid {
+			upvotes = article.Upvotes.Int64
+		}
+		comments := int64(0)
+		if article.CommentCount.Valid {
+			comments = article.CommentCount.Int64
+		}
+
+		if upvotes >= int64(minUpvotes) && comments >= int64(minComments) {
+			filtered = append(filtered, article)
+		}
+	}
+
 	if offset >= len(filtered) {
 		return []*models.Article{}, nil
 	}

--- a/backend/internal/store/mockstore_test.go
+++ b/backend/internal/store/mockstore_test.go
@@ -1,34 +1,36 @@
 // Package store provides an interface and implementations for article storage and retrieval.
-// It includes tests for the MockStore type, which simulates a testing double for the Store interface.
-
+// This file contains comprehensive tests for the MockStore type, which serves as a testing double for the Store interface.
 package store
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/k-zehnder/gophersignal/backend/internal/models"
 )
 
+// TestMockStore_GetArticles verifies basic article retrieval functionality with pagination.
 func TestMockStore_GetArticles(t *testing.T) {
-	// Prepare expected articles for the mock store.
+	// Setup test data and mock store.
 	expectedArticles := []*models.Article{
 		{Title: "Test Article 1"},
 	}
 	mockStore := NewMockStore(expectedArticles, nil, nil)
 
-	// Call GetArticles with pagination parameters (limit, offset).
+	// Execute GetArticles with full result range.
 	articles, err := mockStore.GetArticles(len(expectedArticles), 0)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	// Verify that the number of articles returned matches the expected number.
+	// Validate result count matches expectation.
 	if len(articles) != len(expectedArticles) {
 		t.Fatalf("Expected %d articles, got %d", len(expectedArticles), len(articles))
 	}
 
-	// Check if the returned articles match the expected ones.
+	// Verify individual article contents.
 	for i, article := range articles {
 		if article.Title != expectedArticles[i].Title {
 			t.Errorf("Expected title %s, got %s", expectedArticles[i].Title, article.Title)
@@ -36,28 +38,23 @@ func TestMockStore_GetArticles(t *testing.T) {
 	}
 }
 
+// TestMockStore_SaveArticles validates the article persistence mechanism.
 func TestMockStore_SaveArticles(t *testing.T) {
-	// Initialize a mock store without any pre-existing articles.
 	mockStore := NewMockStore(nil, nil, nil)
-
-	// Define articles to be saved in the mock store.
 	articles := []*models.Article{
 		{Title: "Test Article 1"},
 		{Title: "Test Article 2"},
 	}
 
-	// Attempt to save articles in the mock store.
 	err := mockStore.SaveArticles(articles)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	// Verify that the mock store now contains the expected number of articles.
 	if len(mockStore.Articles) != len(articles) {
 		t.Fatalf("Expected %d articles, got %d", len(articles), len(mockStore.Articles))
 	}
 
-	// Confirm that each saved article matches the corresponding input article.
 	for i, article := range mockStore.Articles {
 		if article.Title != articles[i].Title {
 			t.Errorf("Expected title %s, got %s", articles[i].Title, article.Title)
@@ -65,32 +62,30 @@ func TestMockStore_SaveArticles(t *testing.T) {
 	}
 }
 
+// TestMockStore_SaveArticles_Error verifies error propagation in save operations.
 func TestMockStore_SaveArticles_Error(t *testing.T) {
-	// Create a predefined error to be returned by the mock store.
 	expectedErr := errors.New("save error")
 	mockStore := NewMockStore(nil, expectedErr, nil)
 
-	// Call SaveArticles, which should trigger the predefined error.
 	err := mockStore.SaveArticles([]*models.Article{{Title: "Test Article"}})
 	if err != expectedErr {
 		t.Fatalf("Expected error: %v, got: %v", expectedErr, err)
 	}
 }
 
+// TestMockStore_GetArticles_Error checks error handling in retrieval operations.
 func TestMockStore_GetArticles_Error(t *testing.T) {
-	// Set a predefined error to be returned by the mock store during GetArticles.
 	expectedErr := errors.New("get error")
 	mockStore := NewMockStore(nil, nil, expectedErr)
 
-	// Attempt to retrieve articles, expecting the predefined error to be returned.
 	_, err := mockStore.GetArticles(10, 0)
 	if err != expectedErr {
 		t.Fatalf("Expected error: %v, got: %v", expectedErr, err)
 	}
 }
 
+// TestMockStore_GetFilteredArticles_NoFilter verifies unfiltered retrieval.
 func TestMockStore_GetFilteredArticles_NoFilter(t *testing.T) {
-	// Prepare a list of articles with various flagged/dead/dupe values.
 	articles := []*models.Article{
 		{Title: "Article 1", Flagged: false, Dead: false, Dupe: false},
 		{Title: "Article 2", Flagged: true, Dead: false, Dupe: false},
@@ -99,7 +94,6 @@ func TestMockStore_GetFilteredArticles_NoFilter(t *testing.T) {
 	}
 	mockStore := NewMockStore(articles, nil, nil)
 
-	// When no filters are applied, expect all articles.
 	filtered, err := mockStore.GetFilteredArticles(nil, nil, nil, len(articles), 0)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
@@ -109,8 +103,8 @@ func TestMockStore_GetFilteredArticles_NoFilter(t *testing.T) {
 	}
 }
 
+// TestMockStore_GetFilteredArticles_Flagged validates single-flag filtering.
 func TestMockStore_GetFilteredArticles_Flagged(t *testing.T) {
-	// Prepare a list of articles.
 	articles := []*models.Article{
 		{Title: "Article 1", Flagged: false, Dead: false, Dupe: false},
 		{Title: "Article 2", Flagged: true, Dead: false, Dupe: false},
@@ -119,13 +113,11 @@ func TestMockStore_GetFilteredArticles_Flagged(t *testing.T) {
 	}
 	mockStore := NewMockStore(articles, nil, nil)
 
-	// Apply a filter for flagged = true.
 	flagged := true
 	filtered, err := mockStore.GetFilteredArticles(&flagged, nil, nil, len(articles), 0)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	// Expect Article 2 and Article 3 to match.
 	if len(filtered) != 2 {
 		t.Fatalf("Expected 2 articles, got %d", len(filtered))
 	}
@@ -136,8 +128,8 @@ func TestMockStore_GetFilteredArticles_Flagged(t *testing.T) {
 	}
 }
 
+// TestMockStore_GetFilteredArticles_DeadAndDupe validates combined flag filtering.
 func TestMockStore_GetFilteredArticles_DeadAndDupe(t *testing.T) {
-	// Prepare a list of articles.
 	articles := []*models.Article{
 		{Title: "Article 1", Flagged: false, Dead: false, Dupe: false},
 		{Title: "Article 2", Flagged: true, Dead: true, Dupe: false},
@@ -146,14 +138,12 @@ func TestMockStore_GetFilteredArticles_DeadAndDupe(t *testing.T) {
 	}
 	mockStore := NewMockStore(articles, nil, nil)
 
-	// Apply filters: dead = true and dupe = true.
 	dead := true
 	dupe := true
 	filtered, err := mockStore.GetFilteredArticles(nil, &dead, &dupe, len(articles), 0)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	// Only Article 3 meets both criteria.
 	if len(filtered) != 1 {
 		t.Fatalf("Expected 1 article, got %d", len(filtered))
 	}
@@ -162,8 +152,8 @@ func TestMockStore_GetFilteredArticles_DeadAndDupe(t *testing.T) {
 	}
 }
 
+// TestMockStore_GetFilteredArticles_Error verifies error handling in filtered retrieval.
 func TestMockStore_GetFilteredArticles_Error(t *testing.T) {
-	// Set a predefined error to be returned by GetFilteredArticles.
 	expectedErr := errors.New("get error")
 	mockStore := NewMockStore(nil, nil, expectedErr)
 
@@ -171,4 +161,136 @@ func TestMockStore_GetFilteredArticles_Error(t *testing.T) {
 	if err != expectedErr {
 		t.Fatalf("Expected error: %v, got: %v", expectedErr, err)
 	}
+}
+
+// TestMockStore_GetArticlesWithThresholds validates threshold-based filtering.
+func TestMockStore_GetArticlesWithThresholds(t *testing.T) {
+	articles := []*models.Article{
+		{Title: "Article 1", Upvotes: models.NewNullableInt(50), CommentCount: models.NewNullableInt(10)},
+		{Title: "Article 2", Upvotes: models.NewNullableInt(30), CommentCount: models.NewNullableInt(5)},
+		{Title: "Article 3", Upvotes: models.NewNullableInt(40), CommentCount: models.NewNullableInt(15)},
+	}
+	mockStore := NewMockStore(articles, nil, nil)
+
+	t.Run("MeetBothThresholds", func(t *testing.T) {
+		result, err := mockStore.GetArticlesWithThresholds(10, 0, 40, 10)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(result) != 2 {
+			t.Fatalf("Expected 2 articles, got %d", len(result))
+		}
+	})
+
+	t.Run("ZeroThresholds", func(t *testing.T) {
+		result, err := mockStore.GetArticlesWithThresholds(10, 0, 0, 0)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(result) != len(articles) {
+			t.Fatalf("Expected %d articles, got %d", len(articles), len(result))
+		}
+	})
+}
+
+// TestMockStore_GetArticlesWithThresholdsAndFilters validates combined filtering.
+func TestMockStore_GetArticlesWithThresholdsAndFilters(t *testing.T) {
+	articles := []*models.Article{
+		{Title: "Article 1", Upvotes: models.NewNullableInt(50), CommentCount: models.NewNullableInt(10), Flagged: false, Dead: false, Dupe: false},
+		{Title: "Article 2", Upvotes: models.NewNullableInt(30), CommentCount: models.NewNullableInt(5), Flagged: true, Dead: false, Dupe: false},
+		{Title: "Article 3", Upvotes: models.NewNullableInt(40), CommentCount: models.NewNullableInt(15), Flagged: false, Dead: true, Dupe: false},
+		{Title: "Article 4", Upvotes: models.NewNullableInt(35), CommentCount: models.NewNullableInt(20), Flagged: true, Dead: true, Dupe: true},
+	}
+	mockStore := NewMockStore(articles, nil, nil)
+
+	t.Run("CombinedFilters", func(t *testing.T) {
+		flagged := true
+		dead := true
+		dupe := true
+		result, err := mockStore.GetArticlesWithThresholdsAndFilters(10, 0, 30, 5, &flagged, &dead, &dupe)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(result) != 1 || result[0].Title != "Article 4" {
+			t.Errorf("Expected Article 4, got %v", result)
+		}
+	})
+
+	t.Run("PartialFilters", func(t *testing.T) {
+		flagged := false
+		result, err := mockStore.GetArticlesWithThresholdsAndFilters(10, 0, 40, 10, &flagged, nil, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(result) != 2 {
+			t.Fatalf("Expected 2 articles, got %d", len(result))
+		}
+
+		// Verify both expected articles are present
+		titles := map[string]bool{
+			"Article 1": false,
+			"Article 3": false,
+		}
+		for _, article := range result {
+			titles[article.Title] = true
+		}
+
+		for title, found := range titles {
+			if !found {
+				t.Errorf("Expected article %q not found in results", title)
+			}
+		}
+	})
+}
+
+// TestMockStore_ThresholdMethods_Error verifies error propagation in threshold methods.
+func TestMockStore_ThresholdMethods_Error(t *testing.T) {
+	expectedErr := errors.New("get error")
+	mockStore := NewMockStore(nil, nil, expectedErr)
+
+	t.Run("ThresholdsError", func(t *testing.T) {
+		_, err := mockStore.GetArticlesWithThresholds(10, 0, 0, 0)
+		if err != expectedErr {
+			t.Fatalf("Expected error: %v, got: %v", expectedErr, err)
+		}
+	})
+
+	t.Run("CombinedError", func(t *testing.T) {
+		_, err := mockStore.GetArticlesWithThresholdsAndFilters(10, 0, 0, 0, nil, nil, nil)
+		if err != expectedErr {
+			t.Fatalf("Expected error: %v, got: %v", expectedErr, err)
+		}
+	})
+}
+
+// TestMockStore_Pagination validates pagination behavior across methods.
+func TestMockStore_Pagination(t *testing.T) {
+	articles := make([]*models.Article, 20)
+	for i := range articles {
+		articles[i] = &models.Article{Title: fmt.Sprintf("Article %d", i+1)}
+	}
+	mockStore := NewMockStore(articles, nil, nil)
+
+	t.Run("LimitOffset", func(t *testing.T) {
+		result, err := mockStore.GetArticles(5, 10)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(result) != 5 {
+			t.Fatalf("Expected 5 articles, got %d", len(result))
+		}
+		if !strings.Contains(result[0].Title, "Article 11") {
+			t.Errorf("Expected first article to be Article 11, got %s", result[0].Title)
+		}
+	})
+
+	t.Run("OffsetExceedsResults", func(t *testing.T) {
+		result, err := mockStore.GetArticlesWithThresholds(10, 25, 0, 0)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(result) != 0 {
+			t.Fatalf("Expected empty result, got %d articles", len(result))
+		}
+	})
 }

--- a/rss/src/services/articles.rs
+++ b/rss/src/services/articles.rs
@@ -38,6 +38,12 @@ impl ArticlesClient for HttpArticlesClient {
         if let Some(dupe) = query.dupe {
             params.push(("dupe", dupe.to_string()));
         }
+        if let Some(min_upvotes) = query.min_upvotes {
+            params.push(("min_upvotes", min_upvotes.to_string()));
+        }
+        if let Some(min_comments) = query.min_comments {
+            params.push(("min_comments", min_comments.to_string()));
+        }
         if !params.is_empty() {
             request = request.query(&params);
         }


### PR DESCRIPTION
## Description

This pull request makes progress on FR #386 by adding configurable filtering for upvotes and comments in the RSS feed generator. With these changes, users can now tailor their feed by specifying `min_upvotes` and `min_comments` query parameters, which helps adjust the signal-to-noise ratio and improve the overall user experience (great suggestion by `@thiswillbeyourgithub`.

- FR: configurable point or comment threshold for RSS (#386)

## Changes Made

- Updated the `RssQuery` struct to include `min_upvotes` and `min_comments` for filtering.
- Modified `ArticlesHandler` and `ArticlesClient` to forward and process the new threshold parameters.
- Added Swagger annotations for the new query parameters and updated unit tests to verify threshold filtering.

## Testing

- Unit tests have been updated to ensure that threshold filtering works correctly with various values.

## Checklist

- [x] My code follows the style guidelines and best practices of this project.
- [x] I have reviewed and tested the code changes thoroughly.
- [x] I have added or updated unit tests to cover the modified code.
- [x] All existing unit tests pass with the changes.
- [x] The changes do not introduce any known security vulnerabilities.
- [x] I have considered the impact of these changes on performance, scalability, and maintainability.
- [x] The documentation has been updated to reflect the changes introduced (if applicable).

## Related Issues

- FR: configurable point or comment threshold for RSS (#386)
