### PR TITLE
refactor: Embed never-hallucinate guard in prompt instructions

### DIFF
--- a/hackernews_scraper/src/services/articleSummarizer.ts
+++ b/hackernews_scraper/src/services/articleSummarizer.ts
@@ -5,7 +5,7 @@ import { SingleBar, Presets } from 'cli-progress';
 import { Article, OllamaConfig, SummaryResponseSchema } from '../types/index';
 import Instructor from '@instructor-ai/instructor';
 
-// Creates the article summarizer
+// Creates the article summarizer.
 const createArticleSummarizer = (
   client: ReturnType<typeof Instructor>,
   config: OllamaConfig,

--- a/hackernews_scraper/src/services/articleSummarizer.ts
+++ b/hackernews_scraper/src/services/articleSummarizer.ts
@@ -5,7 +5,7 @@ import { SingleBar, Presets } from 'cli-progress';
 import { Article, OllamaConfig, SummaryResponseSchema } from '../types/index';
 import Instructor from '@instructor-ai/instructor';
 
-// Creates the article summarizer.
+// Creates the article summarizer
 const createArticleSummarizer = (
   client: ReturnType<typeof Instructor>,
   config: OllamaConfig,
@@ -36,9 +36,8 @@ const createArticleSummarizer = (
     title: string,
     content: string
   ): Promise<string> => {
-    // Abort if no real content to work with
     if (!content || content.trim().length < MIN_CONTENT_LENGTH) {
-      return 'ERROR: Article content missing or too short to summarize.';
+      return 'No summary available';
     }
 
     const truncatedContent = content.slice(0, MAX_CONTENT_LENGTH);
@@ -51,7 +50,7 @@ const createArticleSummarizer = (
       SUMMARY REQUEST
       ---------------
       INSTRUCTIONS:
-      - If the article content is missing, unreadable, or under ${MIN_CONTENT_LENGTH} characters, respond with ERROR (all caps) and do NOT make anything up.
+      - If the article content is missing, unreadable, or under ${MIN_CONTENT_LENGTH} characters, return "No summary available".
       - NEVER hallucinate or fabricate content; only summarize what’s provided.
       - Provide a clear, concise summary of the Hacker News article.
       - The summary must be exactly 5 lines long, with each line serving a unique role:

--- a/hackernews_scraper/src/services/articleSummarizer.ts
+++ b/hackernews_scraper/src/services/articleSummarizer.ts
@@ -13,6 +13,7 @@ const createArticleSummarizer = (
 ) => {
   const MAX_CONTENT_LENGTH = config.maxContentLength || 2000;
   const MAX_OUTPUT_TOKENS = config.maxSummaryLength || 150;
+  const MIN_CONTENT_LENGTH = 300;
 
   // Replace special HTML characters
   const sanitizeInput = (text: string) =>
@@ -35,6 +36,11 @@ const createArticleSummarizer = (
     title: string,
     content: string
   ): Promise<string> => {
+    // Abort if no real content to work with
+    if (!content || content.trim().length < MIN_CONTENT_LENGTH) {
+      return 'ERROR: Article content missing or too short to summarize.';
+    }
+
     const truncatedContent = content.slice(0, MAX_CONTENT_LENGTH);
     const truncationNotice =
       content.length > MAX_CONTENT_LENGTH
@@ -45,6 +51,8 @@ const createArticleSummarizer = (
       SUMMARY REQUEST
       ---------------
       INSTRUCTIONS:
+      - If the article content is missing, unreadable, or under ${MIN_CONTENT_LENGTH} characters, respond with ERROR (all caps) and do NOT make anything up.
+      - NEVER hallucinate or fabricate content; only summarize what’s provided.
       - Provide a clear, concise summary of the Hacker News article.
       - The summary must be exactly 5 lines long, with each line serving a unique role:
         * Line 1: Provide concise context.
@@ -72,7 +80,7 @@ const createArticleSummarizer = (
           },
         ],
         max_tokens: MAX_OUTPUT_TOKENS,
-        temperature: 0.5,
+        temperature: 0.2,
         top_p: 0.9,
         response_model: { schema, name: 'SummarySchema' },
       });


### PR DESCRIPTION
## Description

Address https://github.com/k-zehnder/gophersignal/issues/419 by improving summarizer reliability: articles under the minimum length now return `"No summary available"`, the prompt forbids hallucination, and randomness is reduced.

## Changes Made

- Enforce a 300‑character minimum and return `No summary available` for too‑short content  
- Update the system prompt to forbid hallucination and set `temperature` to 0.2

## Testing

- Verified that inputs under 300 characters return `No summary available`  
- Ran full-length articles and confirmed five‑line summaries remain accurate

## Checklist

- [x] My code follows the style guidelines and best practices of this project.  
- [x] I have reviewed and tested the code changes thoroughly.  
- [x] I have added or updated unit tests to cover the modified code and ensure its correctness.  
- [x] All existing unit tests pass with the changes.  
- [x] The changes do not introduce any known security vulnerabilities.  
- [x] I have considered the impact of these changes on performance, scalability, and maintainability.  
- [x] The documentation has been updated to reflect the changes introduced (if applicable).  
