### PR TITLE
fix: RSS duplication for reposted articles by using hn_id as guid

### DIFF
--- a/rss/src/routes/rss.rs
+++ b/rss/src/routes/rss.rs
@@ -22,120 +22,139 @@ pub struct RssQuery {
     pub min_comments: Option<u32>,
 }
 
-/// Generate the RSS feed.
+/// Generates the RSS feed title based on the query filters.
+fn generate_title(query: &RssQuery) -> String {
+    let mut components = Vec::with_capacity(4);
+
+    // Boolean filters
+    [query.flagged, query.dead, query.dupe]
+        .iter()
+        .zip(["Flagged", "Dead", "Dupe"])
+        .filter_map(|(flag, label)| flag.and_then(|f| f.then_some(label)))
+        .for_each(|label| components.push(label));
+
+    // Threshold filters
+    let has_thresholds = [query.min_upvotes, query.min_comments]
+        .iter()
+        .any(|&v| v.filter(|&x| x > 0).is_some());
+
+    if has_thresholds {
+        components.push("Filtered");
+    }
+
+    match components.is_empty() {
+        true => "Gopher Signal".into(),
+        false => format!("Gopher Signal - {}", components.join(", ")),
+    }
+}
+
+/// Builds an RSS item from an article, including title, description, etc.
+fn build_item(article: &Article) -> rss::Item {
+    let (guid_value, is_permalink) = extract_hn_guid(&article.link);
+    let domain = extract_domain(&article.link);
+    let summary = article.summary.as_deref().unwrap_or("No summary");
+
+    ItemBuilder::default()
+        .title(Some(article.title.clone()))
+        .link(Some(article.link.clone()))
+        .description(Some(format!(
+            "{}<br><br><small>{}</small>",
+            encode_minimal(summary),
+            build_info(article, &domain)
+        )))
+        .pub_date(Some(compute_pub_date(article)))
+        .guid(Some(Guid {
+            value: guid_value,
+            permalink: is_permalink,
+        }))
+        .build()
+}
+
+/// Computes the publication date for an article, adjusting by article ID.
+fn compute_pub_date(article: &Article) -> String {
+    let base_date = article
+        .published_at
+        .as_deref()
+        .unwrap_or(&article.created_at);
+    let offset = chrono::Duration::seconds(article.id.into());
+
+    DateTime::parse_from_rfc3339(base_date)
+        .unwrap_or_else(|_| Utc::now().into())
+        .checked_add_signed(offset)
+        .unwrap_or_else(|| Utc::now().into())
+        .to_rfc2822()
+}
+
+/// Extracts the Hacker News GUID from a link if it points to a Hacker News article.
+fn extract_hn_guid(link: &str) -> (String, bool) {
+    Url::parse(link)
+        .ok()
+        .and_then(|url| {
+            if url.host_str() != Some("news.ycombinator.com") {
+                return None;
+            }
+
+            url.query_pairs()
+                .find(|(k, _)| k == "id")
+                .map(|(_, v)| (format!("hn_id={}", v), false))
+        })
+        .unwrap_or_else(|| (link.to_string(), false))
+}
+
+/// Extracts the domain from the article's link.
+fn extract_domain(link: &str) -> String {
+    Url::parse(link)
+        .ok()
+        .and_then(|url| url.host_str().map(ToString::to_string))
+        .unwrap_or_else(|| "source".into())
+}
+
+/// Builds additional information for an RSS item, including upvotes, comments, and source.
+fn build_info(article: &Article, domain: &str) -> String {
+    let comment_link = article.comment_link.as_deref().unwrap_or("#");
+    let comment_count = article.comment_count.unwrap_or(0);
+
+    let comment_text = if comment_count == 0 {
+        "💬 0 comments".into()
+    } else {
+        format!(
+            "💬 <a href=\"{}\">{}</a>",
+            encode_minimal(comment_link),
+            comment_count
+        )
+    };
+
+    [
+        format!("▲ {}", article.upvotes.unwrap_or(0)),
+        comment_text,
+        format!(
+            "via <a href=\"{}\">{}</a>",
+            encode_minimal(&article.link),
+            encode_minimal(domain)
+        ),
+    ]
+    .join(" · ")
+}
+
+/// Main function to generate the RSS feed using articles fetched via `ArticlesClient`.
 pub async fn generate_rss_feed<T: ArticlesClient + Clone>(
     Query(query): Query<RssQuery>,
     Extension(config): Extension<AppConfig>,
     Extension(client): Extension<T>,
 ) -> Result<Response<String>, AppError> {
     let mut articles = client.fetch_articles(&query, &config).await?;
-    articles.sort_by(|a, b| b.id.cmp(&a.id));
-
-    // Build title components.
-    let mut components = Vec::new();
-
-    // Add boolean filters.
-    if query.flagged == Some(true) {
-        components.push("Flagged");
-    }
-    if query.dead == Some(true) {
-        components.push("Dead");
-    }
-    if query.dupe == Some(true) {
-        components.push("Dupe");
-    }
-
-    // Add threshold filters.
-    let has_thresholds = query.min_upvotes.filter(|&v| v > 0).is_some()
-        || query.min_comments.filter(|&c| c > 0).is_some();
-
-    if has_thresholds {
-        components.push("Filtered");
-    }
-
-    // Construct final title.
-    let title = match components.is_empty() {
-        true => "Gopher Signal".to_string(),
-        false => format!("Gopher Signal - {}", components.join(", ")),
-    };
-
-    let items: Vec<_> = articles.iter().map(build_item).collect();
+    articles.sort_by_key(|a| std::cmp::Reverse(a.id));
 
     let channel = ChannelBuilder::default()
-        .title(title)
+        .title(generate_title(&query))
         .link("https://gophersignal.com")
         .description("Latest articles from Gopher Signal")
         .last_build_date(Utc::now().to_rfc2822())
-        .items(items)
+        .items(articles.iter().map(build_item).collect::<Vec<_>>())
         .build();
 
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, "application/rss+xml")
         .body(channel.to_string())?)
-}
-
-fn build_item(article: &Article) -> rss::Item {
-    // Compute a unique publication date using the article ID as an offset.
-    let id_offset = chrono::Duration::seconds(article.id as i64);
-    let pub_date =
-        DateTime::parse_from_rfc3339(&article.published_at.as_ref().unwrap_or(&article.created_at))
-            .unwrap_or_else(|_| Utc::now().into())
-            .checked_add_signed(id_offset)
-            .unwrap()
-            .to_rfc2822();
-
-    // Use full HN URL as <guid> if it's a Hacker News link.
-    let (guid_value, is_permalink) = Url::parse(&article.link)
-        .ok()
-        .and_then(|url| {
-            if url.host_str()? == "news.ycombinator.com" {
-                Some((url.as_str().to_string(), true))
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| (article.link.clone(), false));
-
-    // Parse domain for source.
-    let domain = Url::parse(&article.link)
-        .ok()
-        .and_then(|url| url.host_str().map(|h| h.to_string()))
-        .unwrap_or_else(|| "source".to_string());
-
-    let summary = encode_minimal(article.summary.as_deref().unwrap_or("No summary"));
-    let comment_count = article.comment_count.unwrap_or(0);
-    let comment_text = if comment_count > 0 {
-        format!(
-            "💬 <a href=\"{}\">{}</a>",
-            encode_minimal(article.comment_link.as_deref().unwrap_or("#")),
-            comment_count
-        )
-    } else {
-        "💬 0 comments".to_string()
-    };
-    let upvotes = article.upvotes.unwrap_or(0);
-    let info = vec![
-        format!("▲ {}", upvotes),
-        comment_text,
-        format!(
-            "via <a href=\"{}\">{}</a>",
-            encode_minimal(&article.link),
-            encode_minimal(&domain)
-        ),
-    ]
-    .join(" · ");
-
-    let description = format!("{}<br><br><small>{}</small>", summary, info);
-
-    ItemBuilder::default()
-        .title(Some(article.title.clone()))
-        .link(Some(article.link.clone()))
-        .description(Some(description))
-        .pub_date(Some(pub_date))
-        .guid(Some(Guid {
-            value: guid_value,
-            permalink: is_permalink,
-        }))
-        .build()
 }


### PR DESCRIPTION
## Description

This refactor resolves the issue of duplicate entries in the RSS feed for reposted Hacker News articles. The `guid` was previously set to the full URL, causing duplicates. This change uses the article's unique `hn_id` to ensure reposted articles are treated as unique.

- [[[#421](https://github.com/k-zehnder/gophersignal/issues/421)](https://github.com/k-zehnder/gophersignal/issues/421)] – Duplicate entries issue for reposted Hacker News articles.

## Changes Made

- Replaced the full URL in `guid` with the `hn_id` to prevent duplicates in the feed.
- Modularized `hn_id` extraction into a helper function for maintainability.

## Testing

- Manually verified that reposted Hacker News articles no longer cause duplicates in the feed.

## Checklist

- [x] My code follows the style guidelines and best practices of this project.
- [x] I have reviewed and tested the code changes thoroughly.
- [x] I have added or updated unit tests to cover the modified code and ensure its correctness.
- [x] All existing unit tests pass with the changes.
- [x] The changes do not introduce any known security vulnerabilities.
- [x] I have considered the impact of these changes on performance, scalability, and maintainability.
- [x] The documentation has been updated to reflect the changes introduced (if applicable).
