### PR TITLE
fix: Generate stable RSS GUID using Hacker News ID for deduplication

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -3,9 +3,9 @@ USE gophersignal;
 
 CREATE TABLE IF NOT EXISTS articles (
     id INT AUTO_INCREMENT PRIMARY KEY,
+    hn_id INT NOT NULL DEFAULT 0, 
     title VARCHAR(255) NOT NULL,
     link VARCHAR(512) NOT NULL,
-    hn_id INT NOT NULL, 
     article_rank INT NOT NULL, 
     content TEXT,
     summary VARCHAR(2000),

--- a/hackernews_scraper/package-lock.json
+++ b/hackernews_scraper/package-lock.json
@@ -61,6 +61,27 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.1.3.tgz",
+      "integrity": "sha512-u25AyjuNrRFGb1O7KmWEu0ExN6iJMlUmDSlOPW/11JF8khOrIGG6oCoYpC+4mZlthNVhFUahk68lNrNI91f6Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -604,6 +625,121 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.3.tgz",
+      "integrity": "sha512-XBG3talrhid44BY1x3MHzUx/aTG8+x/Zi57M4aTKK9RFB4aLlF3TTSzfzn8nWVHWL3FgAXAxmupmDd6VWww+pw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.9.tgz",
+      "integrity": "sha512-wILs5Zk7BU86UArYBJTPy/FMPPKVKHMj1ycCEyf3VUptol0JNRLFU/BZsJ4aiIHJEbSLiizzRrw8Pc1uAEDrXw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
+      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1369,9 +1505,9 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.37.6",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.6.tgz",
-      "integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
+      "version": "0.38.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.38.5.tgz",
+      "integrity": "sha512-YSa0sYrniWIfsJBabu/YRVG10v5bqWk0PprwERFDEd776nAe/aafkUd68g7vOhVK1xG2H+Pb8e3sAnCOu/V47w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1379,6 +1515,7 @@
         "@open-draft/logger": "^0.3.0",
         "@open-draft/until": "^2.0.0",
         "is-node-process": "^1.2.0",
+        "jsdom": "^26.0.0",
         "outvariant": "^1.4.3",
         "strict-event-emitter": "^0.5.1"
       },
@@ -2529,6 +2666,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.1.tgz",
+      "integrity": "sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.1.2",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -2536,6 +2687,57 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -2554,6 +2756,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.5.3",
@@ -2712,6 +2921,19 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -3444,6 +3666,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3697,6 +3932,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-property": {
       "version": "1.0.2",
@@ -4444,6 +4686,83 @@
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT"
     },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
@@ -4824,13 +5143,13 @@
       }
     },
     "node_modules/nock": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.1.tgz",
-      "integrity": "sha512-IJN4O9pturuRdn60NjQ7YkFt6Rwei7ZKaOwb1tvUIIqTgeD0SDDAX3vrqZD4wcXczeEy/AsUXxpGpP/yHqV7xg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.4.tgz",
+      "integrity": "sha512-86fh+gIKH8H02+y0/HKAOZZXn6OwgzXvl6JYwfjvKkoKxUWz54wIIDU/+w24xzMvk/R8pNVXOrvTubyl+Ml6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mswjs/interceptors": "^0.37.3",
+        "@mswjs/interceptors": "^0.38.5",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
@@ -4913,6 +5232,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -5102,6 +5428,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -5664,10 +6003,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/schema-stream": {
       "version": "3.2.2",
@@ -6011,6 +6370,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar-fs": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
@@ -6060,6 +6426,26 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6078,6 +6464,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -6336,6 +6735,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -6360,6 +6772,29 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -6438,6 +6873,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/hackernews_scraper/src/database/mysql.ts
+++ b/hackernews_scraper/src/database/mysql.ts
@@ -15,7 +15,7 @@ const createMySqlClient = async (config: Config): Promise<DBClient> => {
 
   console.log('Database connected successfully');
 
-  // Inserts multiple articles into the database in bulk
+  // Inserts multiple articles into the database in bulk.
   const saveArticles = async (articles: Article[]): Promise<void> => {
     if (articles.length === 0) return;
 
@@ -25,34 +25,34 @@ const createMySqlClient = async (config: Config): Promise<DBClient> => {
       .slice(0, 19)
       .replace('T', ' ');
 
-    // Map articles to an array-of-arrays for the insert
+    // Map articles to an array-of-arrays for bulk insert
     const values = articles.map(
       ({
-        hn_id,
+        hnId,
         title,
         link,
-        article_rank,
+        articleRank,
         content = '',
         summary,
         upvotes = 0,
-        comment_count = 0,
-        comment_link = '',
+        commentCount = 0,
+        commentLink = '',
         flagged = false,
         dead = false,
         dupe = false,
       }) => [
-        hn_id,
+        hnId,
         title,
         link,
-        article_rank,
+        articleRank,
         content.length > maxContentLength
           ? content.slice(0, maxContentLength)
           : content,
         summary,
         'Hacker News',
         upvotes,
-        comment_count,
-        comment_link,
+        commentCount,
+        commentLink,
         flagged,
         dead,
         dupe,
@@ -82,7 +82,7 @@ const createMySqlClient = async (config: Config): Promise<DBClient> => {
     await connection.query(query, [values]);
   };
 
-  // Updates an article's summary and sets the updated_at timestamp
+  // Updates an article's summary and timestamp.
   const updateArticleSummary = async (
     id: number,
     summary: string
@@ -93,7 +93,7 @@ const createMySqlClient = async (config: Config): Promise<DBClient> => {
     );
   };
 
-  // Marks an article as dead and updates the timestamp
+  // Marks an article as dead with updated timestamp.
   const markArticleAsDead = async (id: number): Promise<void> => {
     await connection.execute(
       'UPDATE articles SET dead = TRUE, updated_at = NOW() WHERE id = ?',
@@ -101,7 +101,7 @@ const createMySqlClient = async (config: Config): Promise<DBClient> => {
     );
   };
 
-  // Marks an article as duplicate and updates the timestamp
+  // Marks an article as duplicate with updated timestamp.
   const markArticleAsDuplicate = async (id: number): Promise<void> => {
     await connection.execute(
       'UPDATE articles SET dupe = TRUE, updated_at = NOW() WHERE id = ?',
@@ -109,12 +109,10 @@ const createMySqlClient = async (config: Config): Promise<DBClient> => {
     );
   };
 
-  // Closes the MySQL database connection
+  // Closes the MySQL database connection.
   const closeDatabaseConnection = async (): Promise<void> => {
-    if (connection) {
-      await connection.end();
-      console.log('Database connection closed');
-    }
+    await connection.end();
+    console.log('Database connection closed');
   };
 
   return {

--- a/hackernews_scraper/src/services/articleScraper.ts
+++ b/hackernews_scraper/src/services/articleScraper.ts
@@ -7,15 +7,13 @@ import { Article, Scraper } from '../types';
 const TOP_BASE_URL = 'https://news.ycombinator.com';
 const FRONT_BASE_URL = 'https://news.ycombinator.com/front';
 
-type ScrapeResult = { articles: Article[]; nextUrl: string | null };
-
 // Creates a Hacker News scraper
 const createHackerNewsScraper = (browser: Browser): Scraper => {
   // Scrapes a page and returns articles and the next URL; isTop distinguishes / vs /front
   const scrapePageWithNext = async (
     pageUrl: string,
-    isTop: boolean = false
-  ): Promise<ScrapeResult> => {
+    isTop = false
+  ): Promise<{ articles: Article[]; nextUrl: string | null }> => {
     const page = await browser.newPage();
     try {
       await page.goto(pageUrl, { waitUntil: 'networkidle2' });
@@ -24,14 +22,16 @@ const createHackerNewsScraper = (browser: Browser): Scraper => {
           const articles: Article[] = [];
           const rows = Array.from(document.querySelectorAll('tr.athing'));
           rows.forEach((row: Element) => {
-            const hn_id = parseInt((row as HTMLElement).id, 10) || 0;
+            const hnIdAttr = row.getAttribute('id');
+            const hnId = hnIdAttr ? parseInt(hnIdAttr, 10) : 0;
+
             const rankElement = row.querySelector(
               'td.title > span.rank'
             ) as HTMLElement | null;
             const rankStr = rankElement
               ? rankElement.innerText.replace(/\D/g, '').trim()
               : '0';
-            const article_rank = parseInt(rankStr, 10) || 0;
+            const articleRank = parseInt(rankStr, 10) || 0;
 
             const titleElement = row.querySelector(
               'td.title > span.titleline a'
@@ -45,12 +45,12 @@ const createHackerNewsScraper = (browser: Browser): Scraper => {
             const flagged = titleText.includes('[flagged]');
             const dead = titleText.includes('[dead]');
             const dupe = titleText.includes('[dupe]');
-            // For /front, include only flagged, dead, or duplicate articles
+
             if (!isTop && !(flagged || dead || dupe)) return;
 
-            let upvotes = 0,
-              comment_count = 0;
-            let comment_link = 'No comments link';
+            let upvotes = 0;
+            let commentCount = 0;
+            let commentLink = 'No comments link';
 
             const subtextRow = row.nextElementSibling;
             if (subtextRow) {
@@ -61,32 +61,32 @@ const createHackerNewsScraper = (browser: Browser): Scraper => {
                   const match = scoreEl.textContent.match(/\d+/);
                   upvotes = match ? parseInt(match[0], 10) : 0;
                 }
+
                 const commentLinkElement = Array.from(
                   subtext.querySelectorAll('a') as NodeListOf<HTMLAnchorElement>
                 ).find((a) => a.textContent?.includes('comment'));
                 if (commentLinkElement) {
                   const match = commentLinkElement.textContent?.match(/\d+/);
-                  comment_count = match ? parseInt(match[0], 10) : 0;
-                  comment_link = commentLinkElement.href;
+                  commentCount = match ? parseInt(match[0], 10) : 0;
+                  commentLink = commentLinkElement.href;
                 }
               }
             }
 
             articles.push({
+              hnId,
               title,
               link,
-              hn_id,
-              article_rank,
+              articleRank,
               flagged,
               dead,
               dupe,
               upvotes,
-              comment_count,
-              comment_link,
+              commentCount,
+              commentLink,
             });
           });
 
-          // Find the "more" button to get the next URL
           const moreLinkElem = document.querySelector(
             'a.morelink'
           ) as HTMLAnchorElement | null;
@@ -99,12 +99,12 @@ const createHackerNewsScraper = (browser: Browser): Scraper => {
                 /day=(\d{4}-\d{2}-\d{2})&p=(\d+)/
               );
               if (match) {
-                const day = match[1];
-                const nextPage = parseInt(match[2], 10);
-                nextUrl = `${frontBase}?day=${day}&p=${nextPage}`;
+                const [_, day, page] = match;
+                nextUrl = `${frontBase}?day=${day}&p=${page}`;
               }
             }
           }
+
           return { articles, nextUrl };
         },
         isTop,
@@ -124,6 +124,7 @@ const createHackerNewsScraper = (browser: Browser): Scraper => {
     let articles: Article[] = [];
     let nextUrl: string | null = TOP_BASE_URL;
     let pageCount = 0;
+
     while (nextUrl) {
       console.log(`Scraping top stories page: ${nextUrl}`);
       const { articles: pageArticles, nextUrl: newNextUrl } =
@@ -133,14 +134,16 @@ const createHackerNewsScraper = (browser: Browser): Scraper => {
       pageCount++;
       if (maxPages && pageCount >= maxPages) break;
     }
+
     return articles;
   };
 
-  // Scrapes flagged articles from the front pages (/front)
-  const scrapeFront = async (maxPages: number = 10): Promise<Article[]> => {
+  // Scrapes flagged, dead, or duplicate articles from /front
+  const scrapeFront = async (maxPages = 10): Promise<Article[]> => {
     let articles: Article[] = [];
     let nextUrl: string | null = FRONT_BASE_URL;
     let pageCount = 0;
+
     while (nextUrl) {
       console.log(`Scraping front page: ${nextUrl}`);
       const { articles: pageArticles, nextUrl: newNextUrl } =
@@ -150,13 +153,15 @@ const createHackerNewsScraper = (browser: Browser): Scraper => {
       pageCount++;
       if (pageCount >= maxPages) break;
     }
+
     return articles;
   };
 
-  // Scrapes front pages for a specific day from (/front)
+  // Scrapes front pages for a specific day (/front)
   const scrapeFrontForDay = async (day: string): Promise<Article[]> => {
     let articles: Article[] = [];
     let nextUrl: string | null = `${FRONT_BASE_URL}?day=${day}&p=1`;
+
     while (nextUrl) {
       console.log(`Scraping front page for ${day}: ${nextUrl}`);
       const { articles: pageArticles, nextUrl: newNextUrl } =
@@ -164,6 +169,7 @@ const createHackerNewsScraper = (browser: Browser): Scraper => {
       articles = articles.concat(pageArticles);
       nextUrl = newNextUrl;
     }
+
     return articles;
   };
 

--- a/hackernews_scraper/src/types/article.ts
+++ b/hackernews_scraper/src/types/article.ts
@@ -2,14 +2,14 @@
 export interface Article {
   title: string;
   link: string;
-  hn_id: number;
-  article_rank: number;
+  hnId: number;
+  articleRank: number;
   flagged: boolean;
   dead: boolean;
   dupe: boolean;
   upvotes: number;
-  comment_count: number;
-  comment_link: string;
+  commentCount: number;
+  commentLink: string;
   content?: string;
   summary?: string;
   category?: string;

--- a/rss/src/routes/rss.rs
+++ b/rss/src/routes/rss.rs
@@ -13,6 +13,7 @@ use rss::{ChannelBuilder, GuidBuilder, ItemBuilder};
 use serde::Deserialize;
 use url::Url;
 
+// Filters for RSS feed.
 #[derive(Deserialize, Debug, Clone)]
 pub struct RssQuery {
     pub flagged: Option<bool>,
@@ -31,36 +32,36 @@ pub async fn generate_rss_feed<T>(
 where
     T: ArticlesClient + Clone,
 {
-    let mut articles = client.fetch_articles(&query, &config).await?;
-    // Sort newest first
+    let articles = client.fetch_articles(&query, &config).await?;
+    let channel = build_rss_channel(articles, &query);
+    build_rss_response(channel)
+}
+
+// Sort by ID descending to have newest first.
+// idx 0 has highest ID giving newest pubDate.
+fn build_rss_channel(mut articles: Vec<Article>, query: &RssQuery) -> rss::Channel {
     articles.sort_by(|a, b| b.id.cmp(&a.id));
+    let total = articles.len();
 
-    let title = build_title(&query);
-
-    // Pass the zero-based index into build_item so we can offset by seconds reliably.
     let items: Vec<_> = articles
         .iter()
         .enumerate()
-        .map(|(idx, article)| build_item(article, idx))
+        .map(|(i, art)| build_rss_item(art, total, i))
         .collect();
 
-    let channel = ChannelBuilder::default()
-        .title(title)
+    ChannelBuilder::default()
+        .title(build_feed_title(query))
         .link("https://gophersignal.com")
         .description("Latest articles from Gopher Signal")
         .last_build_date(Utc::now().to_rfc2822())
         .items(items)
-        .build();
-
-    Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "application/rss+xml; charset=utf-8")
-        .body(channel.to_string())?)
+        .build()
 }
 
-/// Build the RSS feed title from query filters.
-fn build_title(query: &RssQuery) -> String {
+// Build RSS title from active filters.
+fn build_feed_title(query: &RssQuery) -> String {
     let mut parts = Vec::new();
+
     if query.flagged.unwrap_or(false) {
         parts.push("Flagged");
     }
@@ -73,6 +74,7 @@ fn build_title(query: &RssQuery) -> String {
     if query.min_upvotes.unwrap_or(0) > 0 || query.min_comments.unwrap_or(0) > 0 {
         parts.push("Filtered");
     }
+
     if parts.is_empty() {
         "Gopher Signal".into()
     } else {
@@ -80,66 +82,74 @@ fn build_title(query: &RssQuery) -> String {
     }
 }
 
-/// Build a single RSS from an Article, using its index for the pubDate offset.
-fn build_item(article: &Article, index: usize) -> rss::Item {
+// Convert article to RSS item with staggered pubDate.
+fn build_rss_item(article: &Article, total: usize, idx: usize) -> rss::Item {
+    let offset = (total - 1 - idx) as i64;
     ItemBuilder::default()
         .title(Some(article.title.clone()))
-        .description(Some(format!(
-            "{}<br><br><small>{}</small>",
-            encode_minimal(article.summary.as_deref().unwrap_or("No summary")),
-            build_footer(article)
-        )))
-        .pub_date(Some(format_pub_date(&article.created_at, index)))
-        .guid(Some(build_guid(article)))
+        .description(Some(build_item_description(article)))
+        .pub_date(Some(format_pub_date(&article.created_at, offset)))
+        .guid(Some(build_item_guid(article)))
         .build()
 }
 
-/// Format pubDate by adding seconds to `created_at`.
-fn format_pub_date(created_at: &str, index: usize) -> String {
-    let base: DateTime<Utc> = DateTime::parse_from_rfc3339(created_at)
+// Escape summary and append footer.
+fn build_item_description(article: &Article) -> String {
+    let sum = article.summary.as_deref().unwrap_or("No summary");
+    format!(
+        "{}<br><br><small>{}</small>",
+        encode_minimal(sum),
+        build_item_footer(article)
+    )
+}
+
+// Format creation date with offset as RFC2822.
+fn format_pub_date(ts: &str, off: i64) -> String {
+    let base = DateTime::parse_from_rfc3339(ts)
         .unwrap_or_else(|_| Utc::now().into())
         .with_timezone(&Utc);
-
     let dt = base
-        .checked_add_signed(Duration::seconds(index as i64))
+        .checked_add_signed(Duration::seconds(off))
         .unwrap_or(base);
-
     dt.to_rfc2822()
 }
 
-/// Build a stable GUID
-fn build_guid(article: &Article) -> rss::Guid {
+// Convert article to a <guid>.
+fn build_item_guid(article: &Article) -> rss::Guid {
+    let (value, is_permalink) = match article.hn_id {
+        Some(id) if id > 0 => (format!("https://news.ycombinator.com/item?id={}", id), true),
+        _ => (article.link.clone(), false),
+    };
     GuidBuilder::default()
-        .value(match article.hn_id {
-            Some(hn) => format!("https://news.ycombinator.com/item?id={}", hn),
-            None => article.link.clone(),
-        })
-        .permalink(article.hn_id.is_some())
+        .value(value)
+        .permalink(is_permalink)
         .build()
 }
 
-/// Build the footer HTML of upvotes, comments, via domain.
-fn build_footer(article: &Article) -> String {
-    let up = article.upvotes.unwrap_or(0);
-    let comments = article.comment_count.unwrap_or(0);
-    let comment_html = if comments > 0 {
-        format!(
-            "💬 <a href=\"{}\">{}</a>",
-            encode_minimal(article.comment_link.as_deref().unwrap_or("#")),
-            comments
-        )
-    } else {
-        "💬 0 comments".into()
-    };
+// Footer shows upvotes comments link and source domain.
+fn build_item_footer(article: &Article) -> String {
+    let upvotes = article.upvotes.unwrap_or(0);
+    let count = article.comment_count.unwrap_or(0);
+    let clink = article.comment_link.as_deref().unwrap_or("#");
+    let comments = format!("💬 <a href=\"{}\">{}</a>", encode_minimal(clink), count);
     let domain = Url::parse(&article.link)
         .ok()
         .and_then(|u| u.host_str().map(str::to_string))
         .unwrap_or_else(|| "source".into());
     format!(
         "▲ {} · {} · via <a href=\"{}\">{}</a>",
-        up,
-        comment_html,
+        upvotes,
+        comments,
         encode_minimal(&article.link),
         encode_minimal(&domain)
     )
+}
+
+// Wrap channel in HTTP response.
+fn build_rss_response(channel: rss::Channel) -> Result<Response<String>, AppError> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/rss+xml; charset=utf-8")
+        .body(channel.to_string())
+        .map_err(Into::into)
 }


### PR DESCRIPTION
## Description

This refactor eliminates duplicate and broken RSS entries by capturing each story’s Hacker News ID and using its item URL (`https://news.ycombinator.com/item?id=<hn_id>`) as the stable GUID—even for posts without comments.

Addresses [#421](https://github.com/k-zehnder/gophersignal/issues/421)

### Changes Made

- Improved the scraping process to record Hacker News IDs alongside article data.  
- Switched the feed’s GUID logic to use the HN item URL as the unique identifier.  

### Manual Testing

- Compared RSS feeds before and after the change: duplicates no longer appear and GUIDs remain constant across refreshes.  
- Verified that items without an HN ID continue to fall back gracefully to their original link as the GUID.

### Checklist

- [x] Code adheres to project style guidelines  
- [x] Unit tests updated and passing  
- [x] No new security issues introduced  
- [x] Documentation updated to reflect the new feed behavior