### PR TITLE
fix: hopefully preserve newlines in frontend

### DIFF
--- a/frontend/components/ArticleListItem.tsx
+++ b/frontend/components/ArticleListItem.tsx
@@ -42,7 +42,8 @@ const ArticleListItem: React.FC<ArticleListItemProps> = ({ article }) => {
       </Typography>
 
       {/* Summary */}
-      <Typography sx={{ fontSize: '1rem' }}>{article.summary}</Typography>
+      {/* Add white-space: pre-line to preserve newlines from the summary string */}
+      <Typography sx={{ fontSize: '1rem', whiteSpace: 'pre-line' }}>{article.summary}</Typography>
 
       {/* Upvotes & Comments Row */}
       {(article.upvotes || article.comment_count !== undefined) && (

--- a/rss/src/routes/rss.rs
+++ b/rss/src/routes/rss.rs
@@ -91,9 +91,18 @@ fn build_rss_item(article: &Article, total: usize, idx: usize) -> rss::Item {
         .build()
 }
 
-// Escape summary, append inline “model @ hash” if present, then the footer.
+// Escape summary, replace newlines with <br>, append metadata, then the footer.
 fn build_item_description(article: &Article) -> String {
-    let mut html = encode_minimal(article.summary.as_deref().unwrap_or("No summary"));
+    // Get the summary, defaulting to "No summary" if None
+    let summary_text = article.summary.as_deref().unwrap_or("No summary");
+
+    // First, perform minimal HTML escaping
+    let escaped_summary = encode_minimal(summary_text);
+
+    // Then, replace newline characters with <br> tags
+    let mut html = escaped_summary.replace('\n', "<br>");
+
+    // Append model/hash metadata if available
     if let (Some(model), Some(hash)) = (&article.model_name, &article.commit_hash) {
         if !model.is_empty() && !hash.is_empty() {
             html.push_str(&format!(


### PR DESCRIPTION
- **style: Preserve newlines in article summary with white-space: pre-line**
- **feat: Convert newlines to <br> in RSS article summaries**

## Description

 Despite my previous code contribution, I find that the new line in the front end for salaries are still missing. I used my usual LLM setup to try and find the root cause and hopefully these two commits will solve the issue.

## Changes Made

 Change the typography HTML element to not remove new lines and change some of the rust back-end code to replace `\n` by `<br>` for breaking spaces.

## Testing

No testing whatsoever as for the previous contribution.

## Checklist

- [x] My code follows the style guidelines and best practices of this project.
- [ ] I have reviewed and tested the code changes thoroughly.
- [ ] I have added or updated unit tests to cover the modified code and ensure its correctness.
- [ ] All existing unit tests pass with the changes.
- [ ] The changes do not introduce any known security vulnerabilities.
- [ ] I have considered the impact of these changes on performance, scalability, and maintainability.
- [ ] The documentation has been updated to reflect the changes introduced (if applicable).

## Related Issues

#420

## Additional Notes

none
