### PR TITLE
fix: preserve newlines of summaries

### DIFF
--- a/frontend/components/ArticleListItem.tsx
+++ b/frontend/components/ArticleListItem.tsx
@@ -42,7 +42,9 @@ const ArticleListItem: React.FC<ArticleListItemProps> = ({ article }) => {
       </Typography>
 
       {/* Summary */}
-      <Typography sx={{ fontSize: '1rem' }}>{article.summary}</Typography>
+      <Typography sx={{ fontSize: '1rem', whiteSpace: 'pre-line' }}>
+        {article.summary}
+      </Typography>
 
       {/* Upvotes & Comments Row */}
       {(article.upvotes || article.comment_count !== undefined) && (

--- a/rss/src/routes/rss.rs
+++ b/rss/src/routes/rss.rs
@@ -91,9 +91,17 @@ fn build_rss_item(article: &Article, total: usize, idx: usize) -> rss::Item {
         .build()
 }
 
-// Escape the summary and append the footer metadata.
+// Replace newlines with <br>, escape the summary, and append the footer metadata.
 fn build_item_description(article: &Article) -> String {
-    let mut html = encode_minimal(article.summary.as_deref().unwrap_or("No summary"));
+    // Get the raw summary, replace newlines with <br>, then escape.
+    let summary_with_breaks = article
+        .summary
+        .as_deref()
+        .unwrap_or("No summary")
+        .replace('\n', "<br>");
+    let mut html = encode_minimal(&summary_with_breaks);
+
+    // Append the footer.
     html.push_str(&format!(
         "<br><br><small>{}</small>",
         build_item_footer(article)


### PR DESCRIPTION

## Description

This is basically me doing the same thing as in #458 regarding the newlines in both the RSS and the web frontend.

## Changes Made

- **fix: Replace newlines with <br> in RSS item descriptions**
- **style: Preserve newlines in article summary with white-space CSS**

## Testing

No testing as usual

## Checklist

- [ ] My code follows the style guidelines and best practices of this project.
- [ ] I have reviewed and tested the code changes thoroughly.
- [ ] I have added or updated unit tests to cover the modified code and ensure its correctness.
- [ ] All existing unit tests pass with the changes.
- [ ] The changes do not introduce any known security vulnerabilities.
- [ ] I have considered the impact of these changes on performance, scalability, and maintainability.
- [ ] The documentation has been updated to reflect the changes introduced (if applicable).

## Related Issues

#420

## Additional Notes

You mentioned in [this comment](https://github.com/k-zehnder/gophersignal/pull/458#issuecomment-2840711757) that the code had to be modified but the ulterior PR addressed the footer of the RSS, not the newlines.
