### PR TITLE
fix: add thinking key to structured JSON format for ollama models

### DIFF
--- a/hackernews_scraper/src/services/articleSummarizer.ts
+++ b/hackernews_scraper/src/services/articleSummarizer.ts
@@ -5,9 +5,13 @@ import { SingleBar, Presets } from 'cli-progress';
 import Instructor from '@instructor-ai/instructor';
 import { Article, OllamaConfig } from '../types/index';
 
-// Define the structured schema based on the desired 5-line output format
 // Define the structured schema based on the desired multi-line output format
 const StructuredSummarySchema = z.object({
+  thinking: z
+    .string()
+    .describe(
+      'Think step-by-step to analyze the content and plan the summary.'
+    ),
   context: z.string().describe('Context of the article.'),
   core_idea: z.string().describe('Core idea of the article.'),
   insight_1: z.string().describe('First main insight.'),
@@ -74,6 +78,7 @@ export const createArticleSummarizer = (
 
       const systemPrompt = `
 You are a helpful assistant summarizing Hacker News articles. Follow these instructions precisely:
+- Use the 'thinking' field to think step-by-step about the content before generating the summary fields. This field will not be part of the final output.
 - Return "No summary available" if content is missing, unreadable, or you cannot extract the required fields.
 - NEVER hallucinate; summarize only the provided content.
 - Extract the following fields based on the content:
@@ -124,7 +129,7 @@ You are a helpful assistant summarizing Hacker News articles. Follow these instr
         return 'No summary available';
       }
 
-      // Combine the structured fields into the desired multi-line format
+      // Combine the structured fields (excluding 'thinking') into the desired multi-line format
       const combinedSummary = [
         structuredSummary.context,
         structuredSummary.core_idea,


### PR DESCRIPTION
## Description

I was trying to use qwen3:8b and it worked very well but it appears that adding a thinking key first really helped. Also not having a thinking key meant it would put its thinking string in the context key.

## Changes Made

- add a `thinking` key in the structured output, then not include it in the summary.

## Testing

None

## Checklist

- [ ] My code follows the style guidelines and best practices of this project.
- [ ] I have reviewed and tested the code changes thoroughly.
- [ ] I have added or updated unit tests to cover the modified code and ensure its correctness.
- [ ] All existing unit tests pass with the changes.
- [ ] The changes do not introduce any known security vulnerabilities.
- [ ] I have considered the impact of these changes on performance, scalability, and maintainability.
- [ ] The documentation has been updated to reflect the changes introduced (if applicable).

## Related Issues

None

## Additional Notes

Good day
