### PR TITLE
feat: Strip "www." prefix from displayed domain in RSS feed

### DIFF
--- a/rss/src/routes/rss.rs
+++ b/rss/src/routes/rss.rs
@@ -172,6 +172,15 @@ fn build_item_footer(article: &Article) -> String {
     let domain_display = Url::parse(&article.link)
         .ok()
         .and_then(|u| u.host_str().map(str::to_string))
+        .map(|host| {
+            // Check case-insensitively and ensure host is longer than "www."
+            // to prevent panic on slicing if host is exactly "www."
+            if host.len() > 4 && host.to_lowercase().starts_with("www.") {
+                host[4..].to_string() // Slice the original host string
+            } else {
+                host // Return the original host string if no "www." prefix or if host is just "www."
+            }
+        })
         .unwrap_or_else(|| "source".into());
     let domain_html = format!(
         r#"<a href="{href}">🌐 {display}</a>"#,


### PR DESCRIPTION
## Description

domains starting with www. adds nothing but eats lots of horizontal space on mobile

## Changes Made

remove the leading www. if present

## Testing

None

## Checklist

- [ ] My code follows the style guidelines and best practices of this project.
- [ ] I have reviewed and tested the code changes thoroughly.
- [ ] I have added or updated unit tests to cover the modified code and ensure its correctness.
- [ ] All existing unit tests pass with the changes.
- [ ] The changes do not introduce any known security vulnerabilities.
- [ ] I have considered the impact of these changes on performance, scalability, and maintainability.
- [ ] The documentation has been updated to reflect the changes introduced (if applicable).

## Related Issues

Nope

## Additional Notes

I hope you're well
