### PR TITLE
new: quantize ollama kv cache by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ MYSQL_ROOT_PASSWORD=password
 OLLAMA_BASE_URL=http://ollama:11434/api
 OLLAMA_MODEL=llama3:instruct
 OLLAMA_CONTEXT_LENGTH=8192
+# disable if this does not work on your GPU:
+OLLAMA_FLASH_ATTENTION=1
+# takes less VRAM and RAM:
+OLLAMA_KV_CACHE_TYPE=q4_0
 
 # RSS
 RSS_PORT=9090

--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,6 @@ MYSQL_ROOT_PASSWORD=password
 OLLAMA_BASE_URL=http://ollama:11434/api
 OLLAMA_MODEL=llama3:instruct
 OLLAMA_CONTEXT_LENGTH=8192
-# disable if this does not work on your GPU:
-OLLAMA_FLASH_ATTENTION=1
 # takes less VRAM and RAM:
 OLLAMA_KV_CACHE_TYPE=q4_0
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -72,7 +72,6 @@ services:
     environment:
       - OLLAMA_CONFIG=/ollama/config
       - OLLAMA_CONTEXT_LENGTH=8192
-      - OLLAMA_FLASH_ATTENTION=1  # disable if this does not work on your GPU
       - OLLAMA_KV_CACHE_TYPE=q4_0  # takes less VRAM and RAM
     healthcheck:
       test: ['CMD', 'test', '-f', '/tmp/ollama_model_ready']

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -72,6 +72,8 @@ services:
     environment:
       - OLLAMA_CONFIG=/ollama/config
       - OLLAMA_CONTEXT_LENGTH=8192
+      - OLLAMA_FLASH_ATTENTION=1  # disable if this does not work on your GPU
+      - OLLAMA_KV_CACHE_TYPE=q4_0  # takes less VRAM and RAM
     healthcheck:
       test: ['CMD', 'test', '-f', '/tmp/ollama_model_ready']
       interval: 10s


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>

## Description

Better default env values for ollama. But might not work on all gpus.

## Changes Made

- add kv cache quantization to q4_0
- enable flash attention

## Testing

None

## Checklist

- [ ] My code follows the style guidelines and best practices of this project.
- [ ] I have reviewed and tested the code changes thoroughly.
- [ ] I have added or updated unit tests to cover the modified code and ensure its correctness.
- [ ] All existing unit tests pass with the changes.
- [ ] The changes do not introduce any known security vulnerabilities.
- [ ] I have considered the impact of these changes on performance, scalability, and maintainability.
- [ ] The documentation has been updated to reflect the changes introduced (if applicable).

## Related Issues

Nope

## Additional Notes

<3
