### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: write
+  actions: write
+
 jobs:
   build-test-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/k-zehnder/gophersignal/security/code-scanning/2](https://github.com/k-zehnder/gophersignal/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the tasks in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's code.
- `packages: write` for logging into Docker Hub and pushing Docker images.
- `actions: write` for uploading the Go coverage report as an artifact.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
