### PR TITLE
fix: Test globals after TypeScript dependency bump

### DIFF
--- a/hackernews_scraper/src/services/articleSummarizer.ts
+++ b/hackernews_scraper/src/services/articleSummarizer.ts
@@ -30,7 +30,7 @@ export const createArticleSummarizer = (
   // For this change, we ensure `summarizeContent` uses the correct schemas internally.
   // The diff showed `schema: z.AnyZodObject = StructuredSummarySchema`, let's update this for consistency,
   // though summarizeContent will override it.
-  _schema_param_not_directly_used_in_summarize_content: z.AnyZodObject = StructuredSummarySchema // Renamed to clarify
+  _schema_param_not_directly_used_in_summarize_content: z.ZodTypeAny = StructuredSummarySchema // Renamed to clarify
 ) => {
   const MAX_CONTENT_LENGTH = config.maxContentLength || 2000;
   const MAX_OUTPUT_TOKENS = config.maxSummaryLength || 150; // Consider if structured needs more

--- a/hackernews_scraper/tests/workflow.test.ts
+++ b/hackernews_scraper/tests/workflow.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="jest" />
+
 import { createWorkflow } from '../src/workflow';
 import { Services } from '../src/services/createServices';
 


### PR DESCRIPTION
## Description

Fixes TypeScript compilation issues in the Hacker News scraper package after the dev dependency bump by making Jest globals visible to the workflow test and updating a Zod type annotation that is no longer available with the installed Zod version.

## Changes Made

- Added file-local Jest type resolution for `workflow.test.ts` and replaced the removed `z.AnyZodObject` annotation with `z.ZodTypeAny`.

## Testing

- Ran `npm test` successfully and verified TypeScript compilation with `npx tsc --noEmit`.

## Checklist

- [x] My code follows the style guidelines and best practices of this project.
- [x] I have reviewed and tested the code changes thoroughly.
- [x] I have added or updated unit tests to cover the modified code and ensure its correctness.
- [x] All existing unit tests pass with the changes.
- [x] The changes do not introduce any known security vulnerabilities.
- [x] I have considered the impact of these changes on performance, scalability, and maintainability.
- [x] The documentation has been updated to reflect the changes introduced (if applicable).